### PR TITLE
Corrige URLs do registry no website/package-lock.json

### DIFF
--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -6,7 +6,7 @@
   "dependencies": {
     "@babel/code-frame": {
       "version": "7.5.5",
-      "resolved": "https://registry.npm.taobao.org/@babel/code-frame/download/@babel/code-frame-7.5.5.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.5.5.tgz",
       "integrity": "sha1-vAeC9tafe31JUxIZaZuYj2aaj50=",
       "dev": true,
       "requires": {
@@ -15,7 +15,7 @@
     },
     "@babel/core": {
       "version": "7.5.5",
-      "resolved": "https://registry.npm.taobao.org/@babel/core/download/@babel/core-7.5.5.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.5.5.tgz",
       "integrity": "sha1-F7JobvDWvFj5Y93daKtml1VYLDA=",
       "dev": true,
       "requires": {
@@ -37,7 +37,7 @@
     },
     "@babel/generator": {
       "version": "7.5.5",
-      "resolved": "https://registry.npm.taobao.org/@babel/generator/download/@babel/generator-7.5.5.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.5.5.tgz",
       "integrity": "sha1-hzp/k2o8iUkbQ1NtEiRbYmZk488=",
       "dev": true,
       "requires": {
@@ -50,7 +50,7 @@
     },
     "@babel/helper-annotate-as-pure": {
       "version": "7.0.0",
-      "resolved": "https://registry.npm.taobao.org/@babel/helper-annotate-as-pure/download/@babel/helper-annotate-as-pure-7.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.0.0.tgz",
       "integrity": "sha1-Mj053QtQ4Qx8Bsp9djjmhk2MXDI=",
       "dev": true,
       "requires": {
@@ -59,7 +59,7 @@
     },
     "@babel/helper-builder-binary-assignment-operator-visitor": {
       "version": "7.1.0",
-      "resolved": "https://registry.npm.taobao.org/@babel/helper-builder-binary-assignment-operator-visitor/download/@babel/helper-builder-binary-assignment-operator-visitor-7.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/helper-builder-binary-assignment-operator-visitor/-/helper-builder-binary-assignment-operator-visitor-7.1.0.tgz",
       "integrity": "sha1-a2lijf5Ah3mODE7Zjj1Kay+9L18=",
       "dev": true,
       "requires": {
@@ -69,7 +69,7 @@
     },
     "@babel/helper-call-delegate": {
       "version": "7.4.4",
-      "resolved": "https://registry.npm.taobao.org/@babel/helper-call-delegate/download/@babel/helper-call-delegate-7.4.4.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/helper-call-delegate/-/helper-call-delegate-7.4.4.tgz",
       "integrity": "sha1-h8H4yhmtVSpzanonscH8+LH/H0M=",
       "dev": true,
       "requires": {
@@ -80,7 +80,7 @@
     },
     "@babel/helper-create-class-features-plugin": {
       "version": "7.5.5",
-      "resolved": "https://registry.npm.taobao.org/@babel/helper-create-class-features-plugin/download/@babel/helper-create-class-features-plugin-7.5.5.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.5.5.tgz",
       "integrity": "sha1-QB8wLI3bwO3Tb3xrKIfY+hEi5aQ=",
       "dev": true,
       "requires": {
@@ -94,7 +94,7 @@
     },
     "@babel/helper-define-map": {
       "version": "7.5.5",
-      "resolved": "https://registry.npm.taobao.org/@babel/helper-define-map/download/@babel/helper-define-map-7.5.5.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/helper-define-map/-/helper-define-map-7.5.5.tgz",
       "integrity": "sha1-PewywgRvN+CbKMk+sLED/Sol02k=",
       "dev": true,
       "requires": {
@@ -105,7 +105,7 @@
     },
     "@babel/helper-explode-assignable-expression": {
       "version": "7.1.0",
-      "resolved": "https://registry.npm.taobao.org/@babel/helper-explode-assignable-expression/download/@babel/helper-explode-assignable-expression-7.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/helper-explode-assignable-expression/-/helper-explode-assignable-expression-7.1.0.tgz",
       "integrity": "sha1-U3+hP28WdN90WwwA7I/k6ZaByPY=",
       "dev": true,
       "requires": {
@@ -115,7 +115,7 @@
     },
     "@babel/helper-function-name": {
       "version": "7.1.0",
-      "resolved": "https://registry.npm.taobao.org/@babel/helper-function-name/download/@babel/helper-function-name-7.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.1.0.tgz",
       "integrity": "sha1-oM6wFoX3M1XUNgwSR/WCv6/I/1M=",
       "dev": true,
       "requires": {
@@ -126,7 +126,7 @@
     },
     "@babel/helper-get-function-arity": {
       "version": "7.0.0",
-      "resolved": "https://registry.npm.taobao.org/@babel/helper-get-function-arity/download/@babel/helper-get-function-arity-7.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.0.0.tgz",
       "integrity": "sha1-g1ctQyDipGVyY3NBE8QoaLZOScM=",
       "dev": true,
       "requires": {
@@ -135,7 +135,7 @@
     },
     "@babel/helper-hoist-variables": {
       "version": "7.4.4",
-      "resolved": "https://registry.npm.taobao.org/@babel/helper-hoist-variables/download/@babel/helper-hoist-variables-7.4.4.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.4.4.tgz",
       "integrity": "sha1-Api18lyMCcUxAtUqxKmPdz6yhQo=",
       "dev": true,
       "requires": {
@@ -144,7 +144,7 @@
     },
     "@babel/helper-member-expression-to-functions": {
       "version": "7.5.5",
-      "resolved": "https://registry.npm.taobao.org/@babel/helper-member-expression-to-functions/download/@babel/helper-member-expression-to-functions-7.5.5.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.5.5.tgz",
       "integrity": "sha1-H7W47ERTqTxDnun+Ou6kqEt2tZA=",
       "dev": true,
       "requires": {
@@ -153,7 +153,7 @@
     },
     "@babel/helper-module-imports": {
       "version": "7.0.0",
-      "resolved": "https://registry.npm.taobao.org/@babel/helper-module-imports/download/@babel/helper-module-imports-7.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.0.0.tgz",
       "integrity": "sha1-lggbcRHkhtpNLNlxrRpP4hbMLj0=",
       "dev": true,
       "requires": {
@@ -162,7 +162,7 @@
     },
     "@babel/helper-module-transforms": {
       "version": "7.5.5",
-      "resolved": "https://registry.npm.taobao.org/@babel/helper-module-transforms/download/@babel/helper-module-transforms-7.5.5.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.5.5.tgz",
       "integrity": "sha1-+E/4oJA43Lyh/UNVZhpQCTcWW0o=",
       "dev": true,
       "requires": {
@@ -176,7 +176,7 @@
     },
     "@babel/helper-optimise-call-expression": {
       "version": "7.0.0",
-      "resolved": "https://registry.npm.taobao.org/@babel/helper-optimise-call-expression/download/@babel/helper-optimise-call-expression-7.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.0.0.tgz",
       "integrity": "sha1-opIMVwKwc8Fd5REGIAqoytIEl9U=",
       "dev": true,
       "requires": {
@@ -185,13 +185,13 @@
     },
     "@babel/helper-plugin-utils": {
       "version": "7.0.0",
-      "resolved": "https://registry.npm.taobao.org/@babel/helper-plugin-utils/download/@babel/helper-plugin-utils-7.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.0.0.tgz",
       "integrity": "sha1-u7P77phmHFaQNCN8wDlnupm08lA=",
       "dev": true
     },
     "@babel/helper-regex": {
       "version": "7.5.5",
-      "resolved": "https://registry.npm.taobao.org/@babel/helper-regex/download/@babel/helper-regex-7.5.5.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/helper-regex/-/helper-regex-7.5.5.tgz",
       "integrity": "sha1-CqaCT3EAouDonBUnwjk2wVLKs1E=",
       "dev": true,
       "requires": {
@@ -200,7 +200,7 @@
     },
     "@babel/helper-remap-async-to-generator": {
       "version": "7.1.0",
-      "resolved": "https://registry.npm.taobao.org/@babel/helper-remap-async-to-generator/download/@babel/helper-remap-async-to-generator-7.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/helper-remap-async-to-generator/-/helper-remap-async-to-generator-7.1.0.tgz",
       "integrity": "sha1-Nh2AghtvONp1vT8HheziCojF/n8=",
       "dev": true,
       "requires": {
@@ -213,7 +213,7 @@
     },
     "@babel/helper-replace-supers": {
       "version": "7.5.5",
-      "resolved": "https://registry.npm.taobao.org/@babel/helper-replace-supers/download/@babel/helper-replace-supers-7.5.5.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.5.5.tgz",
       "integrity": "sha1-+EzkPfAxIi0rrQaNJibLV5nDS8I=",
       "dev": true,
       "requires": {
@@ -225,7 +225,7 @@
     },
     "@babel/helper-simple-access": {
       "version": "7.1.0",
-      "resolved": "https://registry.npm.taobao.org/@babel/helper-simple-access/download/@babel/helper-simple-access-7.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.1.0.tgz",
       "integrity": "sha1-Ze65VMjCRb6qToWdphiPOdceWFw=",
       "dev": true,
       "requires": {
@@ -235,7 +235,7 @@
     },
     "@babel/helper-split-export-declaration": {
       "version": "7.4.4",
-      "resolved": "https://registry.npm.taobao.org/@babel/helper-split-export-declaration/download/@babel/helper-split-export-declaration-7.4.4.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.4.4.tgz",
       "integrity": "sha1-/5SJSjQL549T8GrwOLIFxJ2ZNnc=",
       "dev": true,
       "requires": {
@@ -244,7 +244,7 @@
     },
     "@babel/helper-wrap-function": {
       "version": "7.2.0",
-      "resolved": "https://registry.npm.taobao.org/@babel/helper-wrap-function/download/@babel/helper-wrap-function-7.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/helper-wrap-function/-/helper-wrap-function-7.2.0.tgz",
       "integrity": "sha1-xOABJEV2nigVtVKW6tQ6lYVJ9vo=",
       "dev": true,
       "requires": {
@@ -256,7 +256,7 @@
     },
     "@babel/helpers": {
       "version": "7.5.5",
-      "resolved": "https://registry.npm.taobao.org/@babel/helpers/download/@babel/helpers-7.5.5.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.5.5.tgz",
       "integrity": "sha1-Y5CNKnOUIinR5mhbwqDnMN3jt14=",
       "dev": true,
       "requires": {
@@ -267,7 +267,7 @@
     },
     "@babel/highlight": {
       "version": "7.5.0",
-      "resolved": "https://registry.npm.taobao.org/@babel/highlight/download/@babel/highlight-7.5.0.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.5.0.tgz",
       "integrity": "sha1-VtETEr2SSPphlZHQJHK+boyzJUA=",
       "dev": true,
       "requires": {
@@ -278,13 +278,13 @@
     },
     "@babel/parser": {
       "version": "7.5.5",
-      "resolved": "https://registry.npm.taobao.org/@babel/parser/download/@babel/parser-7.5.5.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.5.5.tgz",
       "integrity": "sha1-AvB3rIgX099Kgy71neZ1Zeccyks=",
       "dev": true
     },
     "@babel/plugin-proposal-async-generator-functions": {
       "version": "7.2.0",
-      "resolved": "https://registry.npm.taobao.org/@babel/plugin-proposal-async-generator-functions/download/@babel/plugin-proposal-async-generator-functions-7.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-async-generator-functions/-/plugin-proposal-async-generator-functions-7.2.0.tgz",
       "integrity": "sha1-somzBmadzkrSCwJSiJoVdoydQX4=",
       "dev": true,
       "requires": {
@@ -295,7 +295,7 @@
     },
     "@babel/plugin-proposal-class-properties": {
       "version": "7.5.5",
-      "resolved": "https://registry.npm.taobao.org/@babel/plugin-proposal-class-properties/download/@babel/plugin-proposal-class-properties-7.5.5.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-class-properties/-/plugin-proposal-class-properties-7.5.5.tgz",
       "integrity": "sha1-qXTPrh43wxEOcfPGouSLjnGVjNQ=",
       "dev": true,
       "requires": {
@@ -305,7 +305,7 @@
     },
     "@babel/plugin-proposal-decorators": {
       "version": "7.4.4",
-      "resolved": "https://registry.npm.taobao.org/@babel/plugin-proposal-decorators/download/@babel/plugin-proposal-decorators-7.4.4.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-decorators/-/plugin-proposal-decorators-7.4.4.tgz",
       "integrity": "sha1-3psqGoqwGW83jiqC8QtuKjbyHMA=",
       "dev": true,
       "requires": {
@@ -316,7 +316,7 @@
     },
     "@babel/plugin-proposal-json-strings": {
       "version": "7.2.0",
-      "resolved": "https://registry.npm.taobao.org/@babel/plugin-proposal-json-strings/download/@babel/plugin-proposal-json-strings-7.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-json-strings/-/plugin-proposal-json-strings-7.2.0.tgz",
       "integrity": "sha1-Vo7MRGxhSK5rJn8CVREwiR4p8xc=",
       "dev": true,
       "requires": {
@@ -326,7 +326,7 @@
     },
     "@babel/plugin-proposal-object-rest-spread": {
       "version": "7.5.5",
-      "resolved": "https://registry.npm.taobao.org/@babel/plugin-proposal-object-rest-spread/download/@babel/plugin-proposal-object-rest-spread-7.5.5.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-object-rest-spread/-/plugin-proposal-object-rest-spread-7.5.5.tgz",
       "integrity": "sha1-YZOXRPcbp2o65Gte6hilTBbSLlg=",
       "dev": true,
       "requires": {
@@ -336,7 +336,7 @@
     },
     "@babel/plugin-proposal-optional-catch-binding": {
       "version": "7.2.0",
-      "resolved": "https://registry.npm.taobao.org/@babel/plugin-proposal-optional-catch-binding/download/@babel/plugin-proposal-optional-catch-binding-7.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-optional-catch-binding/-/plugin-proposal-optional-catch-binding-7.2.0.tgz",
       "integrity": "sha1-E12B7baKCB5V5W7EhUHs6AZcOPU=",
       "dev": true,
       "requires": {
@@ -346,7 +346,7 @@
     },
     "@babel/plugin-proposal-unicode-property-regex": {
       "version": "7.4.4",
-      "resolved": "https://registry.npm.taobao.org/@babel/plugin-proposal-unicode-property-regex/download/@babel/plugin-proposal-unicode-property-regex-7.4.4.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-unicode-property-regex/-/plugin-proposal-unicode-property-regex-7.4.4.tgz",
       "integrity": "sha1-UB/9mCbAuR2iJpByByKsfLHKnHg=",
       "dev": true,
       "requires": {
@@ -357,7 +357,7 @@
     },
     "@babel/plugin-syntax-async-generators": {
       "version": "7.2.0",
-      "resolved": "https://registry.npm.taobao.org/@babel/plugin-syntax-async-generators/download/@babel/plugin-syntax-async-generators-7.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-async-generators/-/plugin-syntax-async-generators-7.2.0.tgz",
       "integrity": "sha1-aeHw2zTG9aDPfiszI78VmnbIy38=",
       "dev": true,
       "requires": {
@@ -366,7 +366,7 @@
     },
     "@babel/plugin-syntax-decorators": {
       "version": "7.2.0",
-      "resolved": "https://registry.npm.taobao.org/@babel/plugin-syntax-decorators/download/@babel/plugin-syntax-decorators-7.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-decorators/-/plugin-syntax-decorators-7.2.0.tgz",
       "integrity": "sha1-xQsblX3MaeSxEntl4cM+72FXDBs=",
       "dev": true,
       "requires": {
@@ -375,7 +375,7 @@
     },
     "@babel/plugin-syntax-dynamic-import": {
       "version": "7.2.0",
-      "resolved": "https://registry.npm.taobao.org/@babel/plugin-syntax-dynamic-import/download/@babel/plugin-syntax-dynamic-import-7.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-dynamic-import/-/plugin-syntax-dynamic-import-7.2.0.tgz",
       "integrity": "sha1-acFZ/69JmBIhYa2OvF5tH1XfhhI=",
       "dev": true,
       "requires": {
@@ -384,7 +384,7 @@
     },
     "@babel/plugin-syntax-json-strings": {
       "version": "7.2.0",
-      "resolved": "https://registry.npm.taobao.org/@babel/plugin-syntax-json-strings/download/@babel/plugin-syntax-json-strings-7.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-json-strings/-/plugin-syntax-json-strings-7.2.0.tgz",
       "integrity": "sha1-cr0T9v/h0lk4Ep0qGGsR/WKVFHA=",
       "dev": true,
       "requires": {
@@ -393,7 +393,7 @@
     },
     "@babel/plugin-syntax-jsx": {
       "version": "7.2.0",
-      "resolved": "https://registry.npm.taobao.org/@babel/plugin-syntax-jsx/download/@babel/plugin-syntax-jsx-7.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.2.0.tgz",
       "integrity": "sha1-C4WjtLx830zEuL8jYzW5B8oi58c=",
       "dev": true,
       "requires": {
@@ -402,7 +402,7 @@
     },
     "@babel/plugin-syntax-object-rest-spread": {
       "version": "7.2.0",
-      "resolved": "https://registry.npm.taobao.org/@babel/plugin-syntax-object-rest-spread/download/@babel/plugin-syntax-object-rest-spread-7.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-object-rest-spread/-/plugin-syntax-object-rest-spread-7.2.0.tgz",
       "integrity": "sha1-O3o+czUQxX6CC5FCpleayLDfrS4=",
       "dev": true,
       "requires": {
@@ -411,7 +411,7 @@
     },
     "@babel/plugin-syntax-optional-catch-binding": {
       "version": "7.2.0",
-      "resolved": "https://registry.npm.taobao.org/@babel/plugin-syntax-optional-catch-binding/download/@babel/plugin-syntax-optional-catch-binding-7.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-optional-catch-binding/-/plugin-syntax-optional-catch-binding-7.2.0.tgz",
       "integrity": "sha1-qUAT1u2okI3+akd+f57ahWVuz1w=",
       "dev": true,
       "requires": {
@@ -420,7 +420,7 @@
     },
     "@babel/plugin-transform-arrow-functions": {
       "version": "7.2.0",
-      "resolved": "https://registry.npm.taobao.org/@babel/plugin-transform-arrow-functions/download/@babel/plugin-transform-arrow-functions-7.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-arrow-functions/-/plugin-transform-arrow-functions-7.2.0.tgz",
       "integrity": "sha1-mur75Nb/xlY7+Pg3IJFijwB3lVA=",
       "dev": true,
       "requires": {
@@ -429,7 +429,7 @@
     },
     "@babel/plugin-transform-async-to-generator": {
       "version": "7.5.0",
-      "resolved": "https://registry.npm.taobao.org/@babel/plugin-transform-async-to-generator/download/@babel/plugin-transform-async-to-generator-7.5.0.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-async-to-generator/-/plugin-transform-async-to-generator-7.5.0.tgz",
       "integrity": "sha1-iaOEigFmYjtbxIEWS1k2q5R+iH4=",
       "dev": true,
       "requires": {
@@ -440,7 +440,7 @@
     },
     "@babel/plugin-transform-block-scoped-functions": {
       "version": "7.2.0",
-      "resolved": "https://registry.npm.taobao.org/@babel/plugin-transform-block-scoped-functions/download/@babel/plugin-transform-block-scoped-functions-7.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoped-functions/-/plugin-transform-block-scoped-functions-7.2.0.tgz",
       "integrity": "sha1-XTzBHo1d3XUqpkyRSNDbbLef0ZA=",
       "dev": true,
       "requires": {
@@ -449,7 +449,7 @@
     },
     "@babel/plugin-transform-block-scoping": {
       "version": "7.5.5",
-      "resolved": "https://registry.npm.taobao.org/@babel/plugin-transform-block-scoping/download/@babel/plugin-transform-block-scoping-7.5.5.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.5.5.tgz",
       "integrity": "sha1-o185XlQCgi8Q0hGfb44EXjY5os4=",
       "dev": true,
       "requires": {
@@ -459,7 +459,7 @@
     },
     "@babel/plugin-transform-classes": {
       "version": "7.5.5",
-      "resolved": "https://registry.npm.taobao.org/@babel/plugin-transform-classes/download/@babel/plugin-transform-classes-7.5.5.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-classes/-/plugin-transform-classes-7.5.5.tgz",
       "integrity": "sha1-0JQpnZvWgKFKKg7a44MFrWD7Tek=",
       "dev": true,
       "requires": {
@@ -475,7 +475,7 @@
     },
     "@babel/plugin-transform-computed-properties": {
       "version": "7.2.0",
-      "resolved": "https://registry.npm.taobao.org/@babel/plugin-transform-computed-properties/download/@babel/plugin-transform-computed-properties-7.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-computed-properties/-/plugin-transform-computed-properties-7.2.0.tgz",
       "integrity": "sha1-g6ffamWIZbHI9kHVEMbzryICFto=",
       "dev": true,
       "requires": {
@@ -484,7 +484,7 @@
     },
     "@babel/plugin-transform-destructuring": {
       "version": "7.5.0",
-      "resolved": "https://registry.npm.taobao.org/@babel/plugin-transform-destructuring/download/@babel/plugin-transform-destructuring-7.5.0.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.5.0.tgz",
       "integrity": "sha1-9sCf3+P5RRb/B0/od9t7ye8FhVo=",
       "dev": true,
       "requires": {
@@ -493,7 +493,7 @@
     },
     "@babel/plugin-transform-dotall-regex": {
       "version": "7.4.4",
-      "resolved": "https://registry.npm.taobao.org/@babel/plugin-transform-dotall-regex/download/@babel/plugin-transform-dotall-regex-7.4.4.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-dotall-regex/-/plugin-transform-dotall-regex-7.4.4.tgz",
       "integrity": "sha1-NhoUi8lRREMSxpRG127R6o5EUMM=",
       "dev": true,
       "requires": {
@@ -504,7 +504,7 @@
     },
     "@babel/plugin-transform-duplicate-keys": {
       "version": "7.5.0",
-      "resolved": "https://registry.npm.taobao.org/@babel/plugin-transform-duplicate-keys/download/@babel/plugin-transform-duplicate-keys-7.5.0.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-duplicate-keys/-/plugin-transform-duplicate-keys-7.5.0.tgz",
       "integrity": "sha1-xdv1EGv4TN9pEiLAl0wSsd+TGFM=",
       "dev": true,
       "requires": {
@@ -513,7 +513,7 @@
     },
     "@babel/plugin-transform-exponentiation-operator": {
       "version": "7.2.0",
-      "resolved": "https://registry.npm.taobao.org/@babel/plugin-transform-exponentiation-operator/download/@babel/plugin-transform-exponentiation-operator-7.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-exponentiation-operator/-/plugin-transform-exponentiation-operator-7.2.0.tgz",
       "integrity": "sha1-pjhoKJ5bQAf3BU1GSRr1FDV2YAg=",
       "dev": true,
       "requires": {
@@ -523,7 +523,7 @@
     },
     "@babel/plugin-transform-for-of": {
       "version": "7.4.4",
-      "resolved": "https://registry.npm.taobao.org/@babel/plugin-transform-for-of/download/@babel/plugin-transform-for-of-7.4.4.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-for-of/-/plugin-transform-for-of-7.4.4.tgz",
       "integrity": "sha1-Amf8c14kyAi6FzhmxsTRRA/DxVY=",
       "dev": true,
       "requires": {
@@ -532,7 +532,7 @@
     },
     "@babel/plugin-transform-function-name": {
       "version": "7.4.4",
-      "resolved": "https://registry.npm.taobao.org/@babel/plugin-transform-function-name/download/@babel/plugin-transform-function-name-7.4.4.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-function-name/-/plugin-transform-function-name-7.4.4.tgz",
       "integrity": "sha1-4UNhFquwYQwiWQlISHVKxSMJIq0=",
       "dev": true,
       "requires": {
@@ -542,7 +542,7 @@
     },
     "@babel/plugin-transform-literals": {
       "version": "7.2.0",
-      "resolved": "https://registry.npm.taobao.org/@babel/plugin-transform-literals/download/@babel/plugin-transform-literals-7.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-literals/-/plugin-transform-literals-7.2.0.tgz",
       "integrity": "sha1-aQNT6B+SZ9rU/Yz9d+r6hqulPqE=",
       "dev": true,
       "requires": {
@@ -551,7 +551,7 @@
     },
     "@babel/plugin-transform-modules-amd": {
       "version": "7.5.0",
-      "resolved": "https://registry.npm.taobao.org/@babel/plugin-transform-modules-amd/download/@babel/plugin-transform-modules-amd-7.5.0.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-amd/-/plugin-transform-modules-amd-7.5.0.tgz",
       "integrity": "sha1-7wBDXUbaCllhqnKKHS7P8GPk+5E=",
       "dev": true,
       "requires": {
@@ -562,7 +562,7 @@
     },
     "@babel/plugin-transform-modules-commonjs": {
       "version": "7.5.0",
-      "resolved": "https://registry.npm.taobao.org/@babel/plugin-transform-modules-commonjs/download/@babel/plugin-transform-modules-commonjs-7.5.0.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.5.0.tgz",
       "integrity": "sha1-QlEn5gRSMTYIWO6qR6cdde3tenQ=",
       "dev": true,
       "requires": {
@@ -574,7 +574,7 @@
     },
     "@babel/plugin-transform-modules-systemjs": {
       "version": "7.5.0",
-      "resolved": "https://registry.npm.taobao.org/@babel/plugin-transform-modules-systemjs/download/@babel/plugin-transform-modules-systemjs-7.5.0.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.5.0.tgz",
       "integrity": "sha1-51JmoT75QgLbKgYgl3dW9R1S0kk=",
       "dev": true,
       "requires": {
@@ -585,7 +585,7 @@
     },
     "@babel/plugin-transform-modules-umd": {
       "version": "7.2.0",
-      "resolved": "https://registry.npm.taobao.org/@babel/plugin-transform-modules-umd/download/@babel/plugin-transform-modules-umd-7.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-umd/-/plugin-transform-modules-umd-7.2.0.tgz",
       "integrity": "sha1-dnjOdRafCHe46yI1U4wHQmjdAa4=",
       "dev": true,
       "requires": {
@@ -595,7 +595,7 @@
     },
     "@babel/plugin-transform-named-capturing-groups-regex": {
       "version": "7.4.5",
-      "resolved": "https://registry.npm.taobao.org/@babel/plugin-transform-named-capturing-groups-regex/download/@babel/plugin-transform-named-capturing-groups-regex-7.4.5.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-named-capturing-groups-regex/-/plugin-transform-named-capturing-groups-regex-7.4.5.tgz",
       "integrity": "sha1-nSaf0oo3AlgZm0KUc2gTpgu90QY=",
       "dev": true,
       "requires": {
@@ -604,7 +604,7 @@
     },
     "@babel/plugin-transform-new-target": {
       "version": "7.4.4",
-      "resolved": "https://registry.npm.taobao.org/@babel/plugin-transform-new-target/download/@babel/plugin-transform-new-target-7.4.4.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-new-target/-/plugin-transform-new-target-7.4.4.tgz",
       "integrity": "sha1-GNEgQ4sMye6VpH8scryXaPvtYKU=",
       "dev": true,
       "requires": {
@@ -613,7 +613,7 @@
     },
     "@babel/plugin-transform-object-super": {
       "version": "7.5.5",
-      "resolved": "https://registry.npm.taobao.org/@babel/plugin-transform-object-super/download/@babel/plugin-transform-object-super-7.5.5.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-object-super/-/plugin-transform-object-super-7.5.5.tgz",
       "integrity": "sha1-xwAh34NAc8ZethO4Z5zEo4HRqfk=",
       "dev": true,
       "requires": {
@@ -623,7 +623,7 @@
     },
     "@babel/plugin-transform-parameters": {
       "version": "7.4.4",
-      "resolved": "https://registry.npm.taobao.org/@babel/plugin-transform-parameters/download/@babel/plugin-transform-parameters-7.4.4.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-parameters/-/plugin-transform-parameters-7.4.4.tgz",
       "integrity": "sha1-dVbPA/MYvScZ/kySLS2Ai+VXHhY=",
       "dev": true,
       "requires": {
@@ -634,7 +634,7 @@
     },
     "@babel/plugin-transform-regenerator": {
       "version": "7.4.5",
-      "resolved": "https://registry.npm.taobao.org/@babel/plugin-transform-regenerator/download/@babel/plugin-transform-regenerator-7.4.5.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-regenerator/-/plugin-transform-regenerator-7.4.5.tgz",
       "integrity": "sha1-Yp3IJRLFXO4BNB+ye9/LIQNUaA8=",
       "dev": true,
       "requires": {
@@ -643,7 +643,7 @@
     },
     "@babel/plugin-transform-runtime": {
       "version": "7.5.5",
-      "resolved": "https://registry.npm.taobao.org/@babel/plugin-transform-runtime/download/@babel/plugin-transform-runtime-7.5.5.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.5.5.tgz",
       "integrity": "sha1-pjMa+/xZGJ0hNbLglHRFeo49KLw=",
       "dev": true,
       "requires": {
@@ -655,7 +655,7 @@
     },
     "@babel/plugin-transform-shorthand-properties": {
       "version": "7.2.0",
-      "resolved": "https://registry.npm.taobao.org/@babel/plugin-transform-shorthand-properties/download/@babel/plugin-transform-shorthand-properties-7.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-shorthand-properties/-/plugin-transform-shorthand-properties-7.2.0.tgz",
       "integrity": "sha1-YzOu4vjW7n4oYVRXKYk0o7RhmPA=",
       "dev": true,
       "requires": {
@@ -664,7 +664,7 @@
     },
     "@babel/plugin-transform-spread": {
       "version": "7.2.2",
-      "resolved": "https://registry.npm.taobao.org/@babel/plugin-transform-spread/download/@babel/plugin-transform-spread-7.2.2.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-spread/-/plugin-transform-spread-7.2.2.tgz",
       "integrity": "sha1-MQOpq+IvdCttQG7NPNSbd0kZtAY=",
       "dev": true,
       "requires": {
@@ -673,7 +673,7 @@
     },
     "@babel/plugin-transform-sticky-regex": {
       "version": "7.2.0",
-      "resolved": "https://registry.npm.taobao.org/@babel/plugin-transform-sticky-regex/download/@babel/plugin-transform-sticky-regex-7.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-sticky-regex/-/plugin-transform-sticky-regex-7.2.0.tgz",
       "integrity": "sha1-oeRUtZlVYKnB4NU338FQYf0mh+E=",
       "dev": true,
       "requires": {
@@ -683,7 +683,7 @@
     },
     "@babel/plugin-transform-template-literals": {
       "version": "7.4.4",
-      "resolved": "https://registry.npm.taobao.org/@babel/plugin-transform-template-literals/download/@babel/plugin-transform-template-literals-7.4.4.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-template-literals/-/plugin-transform-template-literals-7.4.4.tgz",
       "integrity": "sha1-nSj+p7vOY3+3YSoHUJidgyHUvLA=",
       "dev": true,
       "requires": {
@@ -693,7 +693,7 @@
     },
     "@babel/plugin-transform-typeof-symbol": {
       "version": "7.2.0",
-      "resolved": "https://registry.npm.taobao.org/@babel/plugin-transform-typeof-symbol/download/@babel/plugin-transform-typeof-symbol-7.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-typeof-symbol/-/plugin-transform-typeof-symbol-7.2.0.tgz",
       "integrity": "sha1-EX0rzsL79ktLWdH5gZiUaC0p8rI=",
       "dev": true,
       "requires": {
@@ -702,7 +702,7 @@
     },
     "@babel/plugin-transform-unicode-regex": {
       "version": "7.4.4",
-      "resolved": "https://registry.npm.taobao.org/@babel/plugin-transform-unicode-regex/download/@babel/plugin-transform-unicode-regex-7.4.4.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-regex/-/plugin-transform-unicode-regex-7.4.4.tgz",
       "integrity": "sha1-q0Y0u08U02cov1l4Mis1WHeHlw8=",
       "dev": true,
       "requires": {
@@ -713,7 +713,7 @@
     },
     "@babel/preset-env": {
       "version": "7.3.4",
-      "resolved": "https://registry.npm.taobao.org/@babel/preset-env/download/@babel/preset-env-7.3.4.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.3.4.tgz",
       "integrity": "sha1-iHzzi20jyC8ZtRNSmL2xYAYuM+E=",
       "dev": true,
       "requires": {
@@ -764,7 +764,7 @@
     },
     "@babel/runtime": {
       "version": "7.5.5",
-      "resolved": "https://registry.npm.taobao.org/@babel/runtime/download/@babel/runtime-7.5.5.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.5.5.tgz",
       "integrity": "sha1-dPulbTXvvspEQJHHhQzNSU/S8TI=",
       "dev": true,
       "requires": {
@@ -773,7 +773,7 @@
     },
     "@babel/runtime-corejs2": {
       "version": "7.5.5",
-      "resolved": "https://registry.npm.taobao.org/@babel/runtime-corejs2/download/@babel/runtime-corejs2-7.5.5.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/runtime-corejs2/-/runtime-corejs2-7.5.5.tgz",
       "integrity": "sha1-wyFMCO8gNBr0GH8cn73DV/vslrI=",
       "dev": true,
       "requires": {
@@ -783,7 +783,7 @@
     },
     "@babel/template": {
       "version": "7.4.4",
-      "resolved": "https://registry.npm.taobao.org/@babel/template/download/@babel/template-7.4.4.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.4.4.tgz",
       "integrity": "sha1-9LiNEiVomgj1vDoXSDVFvp5O0jc=",
       "dev": true,
       "requires": {
@@ -794,7 +794,7 @@
     },
     "@babel/traverse": {
       "version": "7.5.5",
-      "resolved": "https://registry.npm.taobao.org/@babel/traverse/download/@babel/traverse-7.5.5.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.5.5.tgz",
       "integrity": "sha1-9mT482jtMpiM1kjan3LVynDxZbs=",
       "dev": true,
       "requires": {
@@ -811,7 +811,7 @@
     },
     "@babel/types": {
       "version": "7.5.5",
-      "resolved": "https://registry.npm.taobao.org/@babel/types/download/@babel/types-7.5.5.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.5.5.tgz",
       "integrity": "sha1-l7n3KOGCeFkJqkq1YmTwkKAo0Yo=",
       "dev": true,
       "requires": {
@@ -822,19 +822,19 @@
     },
     "@hapi/address": {
       "version": "2.0.0",
-      "resolved": "https://registry.npm.taobao.org/@hapi/address/download/@hapi/address-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/@hapi/address/-/address-2.0.0.tgz",
       "integrity": "sha1-nwVGnIjLL9Pc1iR3a1TulcMSEmo=",
       "dev": true
     },
     "@hapi/hoek": {
       "version": "6.2.4",
-      "resolved": "https://registry.npm.taobao.org/@hapi/hoek/download/@hapi/hoek-6.2.4.tgz",
+      "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-6.2.4.tgz",
       "integrity": "sha1-S5X7rMv7qQGFaQiQvfGi+72hBZU=",
       "dev": true
     },
     "@hapi/joi": {
       "version": "15.1.0",
-      "resolved": "https://registry.npm.taobao.org/@hapi/joi/download/@hapi/joi-15.1.0.tgz?cache=0&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2F%40hapi%2Fjoi%2Fdownload%2F%40hapi%2Fjoi-15.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/@hapi/joi/-/joi-15.1.0.tgz",
       "integrity": "sha1-lAy3SbXFXCarOzTONi6CthYsjno=",
       "dev": true,
       "requires": {
@@ -846,13 +846,13 @@
     },
     "@hapi/marker": {
       "version": "1.0.0",
-      "resolved": "https://registry.npm.taobao.org/@hapi/marker/download/@hapi/marker-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/@hapi/marker/-/marker-1.0.0.tgz",
       "integrity": "sha1-ZbCysB0b4GMEiGzptLd7G/shp2k=",
       "dev": true
     },
     "@hapi/topo": {
       "version": "3.1.3",
-      "resolved": "https://registry.npm.taobao.org/@hapi/topo/download/@hapi/topo-3.1.3.tgz?cache=0&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2F%40hapi%2Ftopo%2Fdownload%2F%40hapi%2Ftopo-3.1.3.tgz",
+      "resolved": "https://registry.npmjs.org/@hapi/topo/-/topo-3.1.3.tgz",
       "integrity": "sha1-x6AuDZNlltKfGE5tf9wH6LXvzhE=",
       "dev": true,
       "requires": {
@@ -861,7 +861,7 @@
       "dependencies": {
         "@hapi/hoek": {
           "version": "8.2.0",
-          "resolved": "https://registry.npm.taobao.org/@hapi/hoek/download/@hapi/hoek-8.2.0.tgz",
+          "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-8.2.0.tgz",
           "integrity": "sha1-B5oTO+JA/4Zq2FMuqkamkb3ZERc=",
           "dev": true
         }
@@ -869,7 +869,7 @@
     },
     "@intervolga/optimize-cssnano-plugin": {
       "version": "1.0.6",
-      "resolved": "https://registry.npm.taobao.org/@intervolga/optimize-cssnano-plugin/download/@intervolga/optimize-cssnano-plugin-1.0.6.tgz",
+      "resolved": "https://registry.npmjs.org/@intervolga/optimize-cssnano-plugin/-/optimize-cssnano-plugin-1.0.6.tgz",
       "integrity": "sha1-vnx4RhKLiPapsdEmGgrQbrXA/fg=",
       "dev": true,
       "requires": {
@@ -880,7 +880,7 @@
     },
     "@mrmlnc/readdir-enhanced": {
       "version": "2.2.1",
-      "resolved": "https://registry.npm.taobao.org/@mrmlnc/readdir-enhanced/download/@mrmlnc/readdir-enhanced-2.2.1.tgz",
+      "resolved": "https://registry.npmjs.org/@mrmlnc/readdir-enhanced/-/readdir-enhanced-2.2.1.tgz",
       "integrity": "sha1-UkryQNGjYFJ7cwR17PoTRKpUDd4=",
       "dev": true,
       "requires": {
@@ -890,13 +890,13 @@
     },
     "@nodelib/fs.stat": {
       "version": "1.1.3",
-      "resolved": "https://registry.npm.taobao.org/@nodelib/fs.stat/download/@nodelib/fs.stat-1.1.3.tgz",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-1.1.3.tgz",
       "integrity": "sha1-K1o6s/kYzKSKjHVMCBaOPwPrphs=",
       "dev": true
     },
     "@soda/friendly-errors-webpack-plugin": {
       "version": "1.7.1",
-      "resolved": "https://registry.npm.taobao.org/@soda/friendly-errors-webpack-plugin/download/@soda/friendly-errors-webpack-plugin-1.7.1.tgz",
+      "resolved": "https://registry.npmjs.org/@soda/friendly-errors-webpack-plugin/-/friendly-errors-webpack-plugin-1.7.1.tgz",
       "integrity": "sha1-cG9kvLSouWQrSK46zkRMcDNNYV0=",
       "dev": true,
       "requires": {
@@ -907,19 +907,19 @@
       "dependencies": {
         "ansi-regex": {
           "version": "2.1.1",
-          "resolved": "https://registry.npm.taobao.org/ansi-regex/download/ansi-regex-2.1.1.tgz",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
           "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
           "dev": true
         },
         "ansi-styles": {
           "version": "2.2.1",
-          "resolved": "https://registry.npm.taobao.org/ansi-styles/download/ansi-styles-2.2.1.tgz",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
           "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
           "dev": true
         },
         "chalk": {
           "version": "1.1.3",
-          "resolved": "https://registry.npm.taobao.org/chalk/download/chalk-1.1.3.tgz",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "dev": true,
           "requires": {
@@ -932,7 +932,7 @@
         },
         "strip-ansi": {
           "version": "3.0.1",
-          "resolved": "https://registry.npm.taobao.org/strip-ansi/download/strip-ansi-3.0.1.tgz",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "dev": true,
           "requires": {
@@ -941,7 +941,7 @@
         },
         "supports-color": {
           "version": "2.0.0",
-          "resolved": "https://registry.npm.taobao.org/supports-color/download/supports-color-2.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
           "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
           "dev": true
         }
@@ -949,13 +949,13 @@
     },
     "@types/events": {
       "version": "3.0.0",
-      "resolved": "https://registry.npm.taobao.org/@types/events/download/@types/events-3.0.0.tgz?cache=0&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2F%40types%2Fevents%2Fdownload%2F%40types%2Fevents-3.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/@types/events/-/events-3.0.0.tgz",
       "integrity": "sha1-KGLz9Yqaf3w+eNefEw3U1xwlwqc=",
       "dev": true
     },
     "@types/glob": {
       "version": "7.1.1",
-      "resolved": "https://registry.npm.taobao.org/@types/glob/download/@types/glob-7.1.1.tgz?cache=0&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2F%40types%2Fglob%2Fdownload%2F%40types%2Fglob-7.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/@types/glob/-/glob-7.1.1.tgz",
       "integrity": "sha1-qlmhxuP7xCHgfM0xqUTDDrpSFXU=",
       "dev": true,
       "requires": {
@@ -966,37 +966,37 @@
     },
     "@types/minimatch": {
       "version": "3.0.3",
-      "resolved": "https://registry.npm.taobao.org/@types/minimatch/download/@types/minimatch-3.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-3.0.3.tgz",
       "integrity": "sha1-PcoOPzOyAPx9ETnAzZbBJoyt/Z0=",
       "dev": true
     },
     "@types/node": {
       "version": "12.7.1",
-      "resolved": "https://registry.npm.taobao.org/@types/node/download/@types/node-12.7.1.tgz?cache=0&sync_timestamp=1565213600002&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2F%40types%2Fnode%2Fdownload%2F%40types%2Fnode-12.7.1.tgz",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.7.1.tgz",
       "integrity": "sha1-O1w6Jjk8GbQAhErEIr0PYxqU1p0=",
       "dev": true
     },
     "@types/normalize-package-data": {
       "version": "2.4.0",
-      "resolved": "https://registry.npm.taobao.org/@types/normalize-package-data/download/@types/normalize-package-data-2.4.0.tgz",
+      "resolved": "https://registry.npmjs.org/@types/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
       "integrity": "sha1-5IbQ2XOW15vu3QpuM/RTT/a0lz4=",
       "dev": true
     },
     "@types/q": {
       "version": "1.5.2",
-      "resolved": "https://registry.npm.taobao.org/@types/q/download/@types/q-1.5.2.tgz",
+      "resolved": "https://registry.npmjs.org/@types/q/-/q-1.5.2.tgz",
       "integrity": "sha1-aQoUdbhPKohP0HzXl8APXzE1bqg=",
       "dev": true
     },
     "@vue/babel-helper-vue-jsx-merge-props": {
       "version": "1.0.0",
-      "resolved": "https://registry.npm.taobao.org/@vue/babel-helper-vue-jsx-merge-props/download/@vue/babel-helper-vue-jsx-merge-props-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/@vue/babel-helper-vue-jsx-merge-props/-/babel-helper-vue-jsx-merge-props-1.0.0.tgz",
       "integrity": "sha1-BI/leZWNpAj7eosqPsBQtQpmEEA=",
       "dev": true
     },
     "@vue/babel-plugin-transform-vue-jsx": {
       "version": "1.0.0",
-      "resolved": "https://registry.npm.taobao.org/@vue/babel-plugin-transform-vue-jsx/download/@vue/babel-plugin-transform-vue-jsx-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/@vue/babel-plugin-transform-vue-jsx/-/babel-plugin-transform-vue-jsx-1.0.0.tgz",
       "integrity": "sha1-68vznDEslBFMjE9AfuT2yXqkVDI=",
       "dev": true,
       "requires": {
@@ -1010,7 +1010,7 @@
     },
     "@vue/babel-preset-app": {
       "version": "3.10.0",
-      "resolved": "https://registry.npm.taobao.org/@vue/babel-preset-app/download/@vue/babel-preset-app-3.10.0.tgz?cache=0&sync_timestamp=1565233923530&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2F%40vue%2Fbabel-preset-app%2Fdownload%2F%40vue%2Fbabel-preset-app-3.10.0.tgz",
+      "resolved": "https://registry.npmjs.org/@vue/babel-preset-app/-/babel-preset-app-3.10.0.tgz",
       "integrity": "sha1-P4nWMd0PF0yKcudptV8IHFM8Rnc=",
       "dev": true,
       "requires": {
@@ -1031,7 +1031,7 @@
     },
     "@vue/babel-preset-jsx": {
       "version": "1.1.0",
-      "resolved": "https://registry.npm.taobao.org/@vue/babel-preset-jsx/download/@vue/babel-preset-jsx-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/@vue/babel-preset-jsx/-/babel-preset-jsx-1.1.0.tgz",
       "integrity": "sha1-yAATKfWzcil6MRGiUetPnpVsEmY=",
       "dev": true,
       "requires": {
@@ -1045,7 +1045,7 @@
     },
     "@vue/babel-sugar-functional-vue": {
       "version": "1.0.0",
-      "resolved": "https://registry.npm.taobao.org/@vue/babel-sugar-functional-vue/download/@vue/babel-sugar-functional-vue-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/@vue/babel-sugar-functional-vue/-/babel-sugar-functional-vue-1.0.0.tgz",
       "integrity": "sha1-F+LEyie3SyRNo7kjJA7JHRAEjLM=",
       "dev": true,
       "requires": {
@@ -1054,7 +1054,7 @@
     },
     "@vue/babel-sugar-inject-h": {
       "version": "1.0.0",
-      "resolved": "https://registry.npm.taobao.org/@vue/babel-sugar-inject-h/download/@vue/babel-sugar-inject-h-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/@vue/babel-sugar-inject-h/-/babel-sugar-inject-h-1.0.0.tgz",
       "integrity": "sha1-5e+2xbW3mI3AODGvbRM797zeY0c=",
       "dev": true,
       "requires": {
@@ -1063,7 +1063,7 @@
     },
     "@vue/babel-sugar-v-model": {
       "version": "1.0.0",
-      "resolved": "https://registry.npm.taobao.org/@vue/babel-sugar-v-model/download/@vue/babel-sugar-v-model-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/@vue/babel-sugar-v-model/-/babel-sugar-v-model-1.0.0.tgz",
       "integrity": "sha1-9NpWqmf2WjSb0sJpqV5y5gGvRhM=",
       "dev": true,
       "requires": {
@@ -1077,7 +1077,7 @@
     },
     "@vue/babel-sugar-v-on": {
       "version": "1.1.0",
-      "resolved": "https://registry.npm.taobao.org/@vue/babel-sugar-v-on/download/@vue/babel-sugar-v-on-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/@vue/babel-sugar-v-on/-/babel-sugar-v-on-1.1.0.tgz",
       "integrity": "sha1-Hys17uq7h+r4klkx9NNP2OZASkU=",
       "dev": true,
       "requires": {
@@ -1088,13 +1088,13 @@
     },
     "@vue/cli-overlay": {
       "version": "3.10.0",
-      "resolved": "https://registry.npm.taobao.org/@vue/cli-overlay/download/@vue/cli-overlay-3.10.0.tgz?cache=0&sync_timestamp=1565233925763&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2F%40vue%2Fcli-overlay%2Fdownload%2F%40vue%2Fcli-overlay-3.10.0.tgz",
+      "resolved": "https://registry.npmjs.org/@vue/cli-overlay/-/cli-overlay-3.10.0.tgz",
       "integrity": "sha1-kmbJb7K//TXKlu3Y4eEoTKjADJQ=",
       "dev": true
     },
     "@vue/cli-plugin-babel": {
       "version": "3.10.0",
-      "resolved": "https://registry.npm.taobao.org/@vue/cli-plugin-babel/download/@vue/cli-plugin-babel-3.10.0.tgz",
+      "resolved": "https://registry.npmjs.org/@vue/cli-plugin-babel/-/cli-plugin-babel-3.10.0.tgz",
       "integrity": "sha1-PFMAvW2vMLUykqbDmC46aBy6LBg=",
       "dev": true,
       "requires": {
@@ -1107,7 +1107,7 @@
     },
     "@vue/cli-plugin-eslint": {
       "version": "3.10.0",
-      "resolved": "https://registry.npm.taobao.org/@vue/cli-plugin-eslint/download/@vue/cli-plugin-eslint-3.10.0.tgz?cache=0&sync_timestamp=1565233927009&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2F%40vue%2Fcli-plugin-eslint%2Fdownload%2F%40vue%2Fcli-plugin-eslint-3.10.0.tgz",
+      "resolved": "https://registry.npmjs.org/@vue/cli-plugin-eslint/-/cli-plugin-eslint-3.10.0.tgz",
       "integrity": "sha1-RKKrzsrcW0hU7o/Ep8WTD2YCk7A=",
       "dev": true,
       "requires": {
@@ -1123,7 +1123,7 @@
       "dependencies": {
         "ajv": {
           "version": "5.5.2",
-          "resolved": "https://registry.npm.taobao.org/ajv/download/ajv-5.5.2.tgz?cache=0&sync_timestamp=1563141444360&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fajv%2Fdownload%2Fajv-5.5.2.tgz",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz",
           "integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
           "dev": true,
           "optional": true,
@@ -1136,14 +1136,14 @@
         },
         "ansi-regex": {
           "version": "3.0.0",
-          "resolved": "https://registry.npm.taobao.org/ansi-regex/download/ansi-regex-3.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
           "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
           "dev": true,
           "optional": true
         },
         "cross-spawn": {
           "version": "5.1.0",
-          "resolved": "https://registry.npm.taobao.org/cross-spawn/download/cross-spawn-5.1.0.tgz",
+          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
           "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
           "dev": true,
           "optional": true,
@@ -1155,7 +1155,7 @@
         },
         "debug": {
           "version": "3.2.6",
-          "resolved": "https://registry.npm.taobao.org/debug/download/debug-3.2.6.tgz",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
           "integrity": "sha1-6D0X3hbYp++3cX7b5fsQE17uYps=",
           "dev": true,
           "optional": true,
@@ -1165,7 +1165,7 @@
         },
         "eslint": {
           "version": "4.19.1",
-          "resolved": "https://registry.npm.taobao.org/eslint/download/eslint-4.19.1.tgz",
+          "resolved": "https://registry.npmjs.org/eslint/-/eslint-4.19.1.tgz",
           "integrity": "sha1-MtHWU+HZBAiFS/spbwdux+GGowA=",
           "dev": true,
           "optional": true,
@@ -1212,7 +1212,7 @@
         },
         "eslint-plugin-vue": {
           "version": "4.7.1",
-          "resolved": "https://registry.npm.taobao.org/eslint-plugin-vue/download/eslint-plugin-vue-4.7.1.tgz",
+          "resolved": "https://registry.npmjs.org/eslint-plugin-vue/-/eslint-plugin-vue-4.7.1.tgz",
           "integrity": "sha1-yCm5/GJYLBiXtaC5Sv1E7MpRHmM=",
           "dev": true,
           "optional": true,
@@ -1222,7 +1222,7 @@
         },
         "eslint-scope": {
           "version": "3.7.3",
-          "resolved": "https://registry.npm.taobao.org/eslint-scope/download/eslint-scope-3.7.3.tgz?cache=0&sync_timestamp=1563679289211&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Feslint-scope%2Fdownload%2Feslint-scope-3.7.3.tgz",
+          "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-3.7.3.tgz",
           "integrity": "sha1-u1ByANPRf2AkdjYWC0gmKEsQhTU=",
           "dev": true,
           "optional": true,
@@ -1233,21 +1233,21 @@
         },
         "fast-deep-equal": {
           "version": "1.1.0",
-          "resolved": "https://registry.npm.taobao.org/fast-deep-equal/download/fast-deep-equal-1.1.0.tgz",
+          "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.1.0.tgz",
           "integrity": "sha1-wFNHeBfIa1HaqFPIHgWbcz0CNhQ=",
           "dev": true,
           "optional": true
         },
         "json-schema-traverse": {
           "version": "0.3.1",
-          "resolved": "https://registry.npm.taobao.org/json-schema-traverse/download/json-schema-traverse-0.3.1.tgz",
+          "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.3.1.tgz",
           "integrity": "sha1-NJptRMU6Ud6JtAgFxdXlm0F9M0A=",
           "dev": true,
           "optional": true
         },
         "lru-cache": {
           "version": "4.1.5",
-          "resolved": "https://registry.npm.taobao.org/lru-cache/download/lru-cache-4.1.5.tgz",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.5.tgz",
           "integrity": "sha1-i75Q6oW+1ZvJ4z3KuCNe6bz0Q80=",
           "dev": true,
           "optional": true,
@@ -1258,7 +1258,7 @@
         },
         "strip-ansi": {
           "version": "4.0.0",
-          "resolved": "https://registry.npm.taobao.org/strip-ansi/download/strip-ansi-4.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
           "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
           "dev": true,
           "optional": true,
@@ -1268,7 +1268,7 @@
         },
         "yallist": {
           "version": "2.1.2",
-          "resolved": "https://registry.npm.taobao.org/yallist/download/yallist-2.1.2.tgz",
+          "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
           "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=",
           "dev": true,
           "optional": true
@@ -1277,7 +1277,7 @@
     },
     "@vue/cli-service": {
       "version": "3.10.0",
-      "resolved": "https://registry.npm.taobao.org/@vue/cli-service/download/@vue/cli-service-3.10.0.tgz?cache=0&sync_timestamp=1565233930908&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2F%40vue%2Fcli-service%2Fdownload%2F%40vue%2Fcli-service-3.10.0.tgz",
+      "resolved": "https://registry.npmjs.org/@vue/cli-service/-/cli-service-3.10.0.tgz",
       "integrity": "sha1-HmGvrJ7u1dkCwSRxXClxmr63Q8U=",
       "dev": true,
       "requires": {
@@ -1341,13 +1341,13 @@
       "dependencies": {
         "acorn": {
           "version": "6.2.1",
-          "resolved": "https://registry.npm.taobao.org/acorn/download/acorn-6.2.1.tgz",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.2.1.tgz",
           "integrity": "sha1-PthCLW3sCeYSHMeoQ8qGozCoa1E=",
           "dev": true
         },
         "semver": {
           "version": "6.3.0",
-          "resolved": "https://registry.npm.taobao.org/semver/download/semver-6.3.0.tgz",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
           "integrity": "sha1-7gpkyK9ejO6mdoexM3YeG+y9HT0=",
           "dev": true
         }
@@ -1355,7 +1355,7 @@
     },
     "@vue/cli-shared-utils": {
       "version": "3.10.0",
-      "resolved": "https://registry.npm.taobao.org/@vue/cli-shared-utils/download/@vue/cli-shared-utils-3.10.0.tgz",
+      "resolved": "https://registry.npmjs.org/@vue/cli-shared-utils/-/cli-shared-utils-3.10.0.tgz",
       "integrity": "sha1-nRVvPA72dak5MZBiSJ6YyNPYD34=",
       "dev": true,
       "requires": {
@@ -1375,7 +1375,7 @@
       "dependencies": {
         "semver": {
           "version": "6.3.0",
-          "resolved": "https://registry.npm.taobao.org/semver/download/semver-6.3.0.tgz",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
           "integrity": "sha1-7gpkyK9ejO6mdoexM3YeG+y9HT0=",
           "dev": true
         }
@@ -1383,7 +1383,7 @@
     },
     "@vue/component-compiler-utils": {
       "version": "2.6.0",
-      "resolved": "https://registry.npm.taobao.org/@vue/component-compiler-utils/download/@vue/component-compiler-utils-2.6.0.tgz",
+      "resolved": "https://registry.npmjs.org/@vue/component-compiler-utils/-/component-compiler-utils-2.6.0.tgz",
       "integrity": "sha1-qkbSpvdkdECwuJMkNNIvEjceVDs=",
       "dev": true,
       "requires": {
@@ -1400,7 +1400,7 @@
       "dependencies": {
         "lru-cache": {
           "version": "4.1.5",
-          "resolved": "https://registry.npm.taobao.org/lru-cache/download/lru-cache-4.1.5.tgz",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.5.tgz",
           "integrity": "sha1-i75Q6oW+1ZvJ4z3KuCNe6bz0Q80=",
           "dev": true,
           "requires": {
@@ -1410,13 +1410,13 @@
         },
         "source-map": {
           "version": "0.6.1",
-          "resolved": "https://registry.npm.taobao.org/source-map/download/source-map-0.6.1.tgz",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
           "integrity": "sha1-dHIq8y6WFOnCh6jQu95IteLxomM=",
           "dev": true
         },
         "yallist": {
           "version": "2.1.2",
-          "resolved": "https://registry.npm.taobao.org/yallist/download/yallist-2.1.2.tgz",
+          "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
           "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=",
           "dev": true
         }
@@ -1424,19 +1424,19 @@
     },
     "@vue/preload-webpack-plugin": {
       "version": "1.1.1",
-      "resolved": "https://registry.npm.taobao.org/@vue/preload-webpack-plugin/download/@vue/preload-webpack-plugin-1.1.1.tgz?cache=0&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2F%40vue%2Fpreload-webpack-plugin%2Fdownload%2F%40vue%2Fpreload-webpack-plugin-1.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/@vue/preload-webpack-plugin/-/preload-webpack-plugin-1.1.1.tgz",
       "integrity": "sha1-GHI1MNME9EMCHaIpLW7JUCgmEEo=",
       "dev": true
     },
     "@vue/web-component-wrapper": {
       "version": "1.2.0",
-      "resolved": "https://registry.npm.taobao.org/@vue/web-component-wrapper/download/@vue/web-component-wrapper-1.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/@vue/web-component-wrapper/-/web-component-wrapper-1.2.0.tgz",
       "integrity": "sha1-uw5G8VhafiibTuYGfcxaauYvHdE=",
       "dev": true
     },
     "@webassemblyjs/ast": {
       "version": "1.7.11",
-      "resolved": "https://registry.npm.taobao.org/@webassemblyjs/ast/download/@webassemblyjs/ast-1.7.11.tgz",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/ast/-/ast-1.7.11.tgz",
       "integrity": "sha1-uYhYLK+7Kwlei1VlJvMMkNBXys4=",
       "dev": true,
       "requires": {
@@ -1447,25 +1447,25 @@
     },
     "@webassemblyjs/floating-point-hex-parser": {
       "version": "1.7.11",
-      "resolved": "https://registry.npm.taobao.org/@webassemblyjs/floating-point-hex-parser/download/@webassemblyjs/floating-point-hex-parser-1.7.11.tgz",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/floating-point-hex-parser/-/floating-point-hex-parser-1.7.11.tgz",
       "integrity": "sha1-pp8K9lAuuaPARVVbGmEp09Py4xM=",
       "dev": true
     },
     "@webassemblyjs/helper-api-error": {
       "version": "1.7.11",
-      "resolved": "https://registry.npm.taobao.org/@webassemblyjs/helper-api-error/download/@webassemblyjs/helper-api-error-1.7.11.tgz",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-api-error/-/helper-api-error-1.7.11.tgz",
       "integrity": "sha1-x7a7gQX4QDlRGis5zklPGTgYoyo=",
       "dev": true
     },
     "@webassemblyjs/helper-buffer": {
       "version": "1.7.11",
-      "resolved": "https://registry.npm.taobao.org/@webassemblyjs/helper-buffer/download/@webassemblyjs/helper-buffer-1.7.11.tgz",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-buffer/-/helper-buffer-1.7.11.tgz",
       "integrity": "sha1-MSLUjcxslFbtmC3r4WyPNxAd85s=",
       "dev": true
     },
     "@webassemblyjs/helper-code-frame": {
       "version": "1.7.11",
-      "resolved": "https://registry.npm.taobao.org/@webassemblyjs/helper-code-frame/download/@webassemblyjs/helper-code-frame-1.7.11.tgz",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-code-frame/-/helper-code-frame-1.7.11.tgz",
       "integrity": "sha1-z48QbnRmYqDaKb3vY1/NPRJINks=",
       "dev": true,
       "requires": {
@@ -1474,25 +1474,25 @@
     },
     "@webassemblyjs/helper-fsm": {
       "version": "1.7.11",
-      "resolved": "https://registry.npm.taobao.org/@webassemblyjs/helper-fsm/download/@webassemblyjs/helper-fsm-1.7.11.tgz",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-fsm/-/helper-fsm-1.7.11.tgz",
       "integrity": "sha1-3ziIKmJAgNA/dQP5Pj8XrFrAEYE=",
       "dev": true
     },
     "@webassemblyjs/helper-module-context": {
       "version": "1.7.11",
-      "resolved": "https://registry.npm.taobao.org/@webassemblyjs/helper-module-context/download/@webassemblyjs/helper-module-context-1.7.11.tgz",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-module-context/-/helper-module-context-1.7.11.tgz",
       "integrity": "sha1-2HTXIuUeYqwgJHaTXWScgC+g4gk=",
       "dev": true
     },
     "@webassemblyjs/helper-wasm-bytecode": {
       "version": "1.7.11",
-      "resolved": "https://registry.npm.taobao.org/@webassemblyjs/helper-wasm-bytecode/download/@webassemblyjs/helper-wasm-bytecode-1.7.11.tgz",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-bytecode/-/helper-wasm-bytecode-1.7.11.tgz",
       "integrity": "sha1-3ZoegX8cLrEFtM8QEwk8ufPJywY=",
       "dev": true
     },
     "@webassemblyjs/helper-wasm-section": {
       "version": "1.7.11",
-      "resolved": "https://registry.npm.taobao.org/@webassemblyjs/helper-wasm-section/download/@webassemblyjs/helper-wasm-section-1.7.11.tgz",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-section/-/helper-wasm-section-1.7.11.tgz",
       "integrity": "sha1-nJrEHs+fvP/8lvbSZ14t4zgR5oo=",
       "dev": true,
       "requires": {
@@ -1504,7 +1504,7 @@
     },
     "@webassemblyjs/ieee754": {
       "version": "1.7.11",
-      "resolved": "https://registry.npm.taobao.org/@webassemblyjs/ieee754/download/@webassemblyjs/ieee754-1.7.11.tgz",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/ieee754/-/ieee754-1.7.11.tgz",
       "integrity": "sha1-yVg562N1ejGICq7HtlEtQZGsZAs=",
       "dev": true,
       "requires": {
@@ -1513,7 +1513,7 @@
     },
     "@webassemblyjs/leb128": {
       "version": "1.7.11",
-      "resolved": "https://registry.npm.taobao.org/@webassemblyjs/leb128/download/@webassemblyjs/leb128-1.7.11.tgz",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/leb128/-/leb128-1.7.11.tgz",
       "integrity": "sha1-1yZ6HunEWU/T9+NymIGOxlaH22M=",
       "dev": true,
       "requires": {
@@ -1522,13 +1522,13 @@
     },
     "@webassemblyjs/utf8": {
       "version": "1.7.11",
-      "resolved": "https://registry.npm.taobao.org/@webassemblyjs/utf8/download/@webassemblyjs/utf8-1.7.11.tgz",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/utf8/-/utf8-1.7.11.tgz",
       "integrity": "sha1-Btchjqn9yUpnk6qSIIFg2z0m7oI=",
       "dev": true
     },
     "@webassemblyjs/wasm-edit": {
       "version": "1.7.11",
-      "resolved": "https://registry.npm.taobao.org/@webassemblyjs/wasm-edit/download/@webassemblyjs/wasm-edit-1.7.11.tgz",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-edit/-/wasm-edit-1.7.11.tgz",
       "integrity": "sha1-jHTKR01PlR0B266b1wgU7iKoIAU=",
       "dev": true,
       "requires": {
@@ -1544,7 +1544,7 @@
     },
     "@webassemblyjs/wasm-gen": {
       "version": "1.7.11",
-      "resolved": "https://registry.npm.taobao.org/@webassemblyjs/wasm-gen/download/@webassemblyjs/wasm-gen-1.7.11.tgz",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-gen/-/wasm-gen-1.7.11.tgz",
       "integrity": "sha1-m7upQvIjdWhqb7dZr816ycRdoag=",
       "dev": true,
       "requires": {
@@ -1557,7 +1557,7 @@
     },
     "@webassemblyjs/wasm-opt": {
       "version": "1.7.11",
-      "resolved": "https://registry.npm.taobao.org/@webassemblyjs/wasm-opt/download/@webassemblyjs/wasm-opt-1.7.11.tgz",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-opt/-/wasm-opt-1.7.11.tgz",
       "integrity": "sha1-szHo5874+OLwB9QsOjagWAp9bKc=",
       "dev": true,
       "requires": {
@@ -1569,7 +1569,7 @@
     },
     "@webassemblyjs/wasm-parser": {
       "version": "1.7.11",
-      "resolved": "https://registry.npm.taobao.org/@webassemblyjs/wasm-parser/download/@webassemblyjs/wasm-parser-1.7.11.tgz",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-parser/-/wasm-parser-1.7.11.tgz",
       "integrity": "sha1-bj0g+mo1GfawhO+Tka1YIR77Cho=",
       "dev": true,
       "requires": {
@@ -1583,7 +1583,7 @@
     },
     "@webassemblyjs/wast-parser": {
       "version": "1.7.11",
-      "resolved": "https://registry.npm.taobao.org/@webassemblyjs/wast-parser/download/@webassemblyjs/wast-parser-1.7.11.tgz",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/wast-parser/-/wast-parser-1.7.11.tgz",
       "integrity": "sha1-Jb0RdWLKjAAnIP+BFu+QctnKhpw=",
       "dev": true,
       "requires": {
@@ -1597,7 +1597,7 @@
     },
     "@webassemblyjs/wast-printer": {
       "version": "1.7.11",
-      "resolved": "https://registry.npm.taobao.org/@webassemblyjs/wast-printer/download/@webassemblyjs/wast-printer-1.7.11.tgz",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/wast-printer/-/wast-printer-1.7.11.tgz",
       "integrity": "sha1-xCRbbeJCy1CizJUBdP2/ZceNeBM=",
       "dev": true,
       "requires": {
@@ -1608,19 +1608,19 @@
     },
     "@xtuc/ieee754": {
       "version": "1.2.0",
-      "resolved": "https://registry.npm.taobao.org/@xtuc/ieee754/download/@xtuc/ieee754-1.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/@xtuc/ieee754/-/ieee754-1.2.0.tgz",
       "integrity": "sha1-7vAUoxRa5Hehy8AM0eVSM23Ot5A=",
       "dev": true
     },
     "@xtuc/long": {
       "version": "4.2.1",
-      "resolved": "https://registry.npm.taobao.org/@xtuc/long/download/@xtuc/long-4.2.1.tgz",
+      "resolved": "https://registry.npmjs.org/@xtuc/long/-/long-4.2.1.tgz",
       "integrity": "sha1-XIXWYvdvodNFdXZsXc1mFavNMNg=",
       "dev": true
     },
     "accepts": {
       "version": "1.3.7",
-      "resolved": "https://registry.npm.taobao.org/accepts/download/accepts-1.3.7.tgz",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.7.tgz",
       "integrity": "sha1-UxvHJlF6OytB+FACHGzBXqq1B80=",
       "dev": true,
       "requires": {
@@ -1630,13 +1630,13 @@
     },
     "acorn": {
       "version": "5.7.3",
-      "resolved": "https://registry.npm.taobao.org/acorn/download/acorn-5.7.3.tgz",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.7.3.tgz",
       "integrity": "sha1-Z6ojG/iBKXS4UjWpZ3Hra9B+onk=",
       "dev": true
     },
     "acorn-dynamic-import": {
       "version": "3.0.0",
-      "resolved": "https://registry.npm.taobao.org/acorn-dynamic-import/download/acorn-dynamic-import-3.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/acorn-dynamic-import/-/acorn-dynamic-import-3.0.0.tgz",
       "integrity": "sha1-kBzu5Mf6rvfgetKkfokGddpQong=",
       "dev": true,
       "requires": {
@@ -1645,7 +1645,7 @@
     },
     "acorn-jsx": {
       "version": "3.0.1",
-      "resolved": "https://registry.npm.taobao.org/acorn-jsx/download/acorn-jsx-3.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-3.0.1.tgz",
       "integrity": "sha1-r9+UiPsezvyDSPb7IvRk4ypYs2s=",
       "dev": true,
       "optional": true,
@@ -1655,7 +1655,7 @@
       "dependencies": {
         "acorn": {
           "version": "3.3.0",
-          "resolved": "https://registry.npm.taobao.org/acorn/download/acorn-3.3.0.tgz",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-3.3.0.tgz",
           "integrity": "sha1-ReN/s56No/JbruP/U2niu18iAXo=",
           "dev": true,
           "optional": true
@@ -1664,19 +1664,19 @@
     },
     "acorn-walk": {
       "version": "6.2.0",
-      "resolved": "https://registry.npm.taobao.org/acorn-walk/download/acorn-walk-6.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-6.2.0.tgz",
       "integrity": "sha1-Ejy487hMIXHx9/slJhWxx4prGow=",
       "dev": true
     },
     "address": {
       "version": "1.1.0",
-      "resolved": "https://registry.npm.taobao.org/address/download/address-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/address/-/address-1.1.0.tgz",
       "integrity": "sha1-744EeEf80sW29QwWll+ST9mf5wk=",
       "dev": true
     },
     "ajv": {
       "version": "6.10.2",
-      "resolved": "https://registry.npm.taobao.org/ajv/download/ajv-6.10.2.tgz?cache=0&sync_timestamp=1563141444360&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fajv%2Fdownload%2Fajv-6.10.2.tgz",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.10.2.tgz",
       "integrity": "sha1-086gTWsBeyiUrWkED+yLYj60vVI=",
       "dev": true,
       "requires": {
@@ -1688,49 +1688,49 @@
     },
     "ajv-errors": {
       "version": "1.0.1",
-      "resolved": "https://registry.npm.taobao.org/ajv-errors/download/ajv-errors-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/ajv-errors/-/ajv-errors-1.0.1.tgz",
       "integrity": "sha1-81mGrOuRr63sQQL72FAUlQzvpk0=",
       "dev": true
     },
     "ajv-keywords": {
       "version": "3.4.1",
-      "resolved": "https://registry.npm.taobao.org/ajv-keywords/download/ajv-keywords-3.4.1.tgz",
+      "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.4.1.tgz",
       "integrity": "sha1-75FuJxxkrBIXH9g4TqrmsjRYVNo=",
       "dev": true
     },
     "alphanum-sort": {
       "version": "1.0.2",
-      "resolved": "https://registry.npm.taobao.org/alphanum-sort/download/alphanum-sort-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/alphanum-sort/-/alphanum-sort-1.0.2.tgz",
       "integrity": "sha1-l6ERlkmyEa0zaR2fn0hqjsn74KM=",
       "dev": true
     },
     "ansi-colors": {
       "version": "3.2.4",
-      "resolved": "https://registry.npm.taobao.org/ansi-colors/download/ansi-colors-3.2.4.tgz?cache=0&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fansi-colors%2Fdownload%2Fansi-colors-3.2.4.tgz",
+      "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-3.2.4.tgz",
       "integrity": "sha1-46PaS/uubIapwoViXeEkojQCb78=",
       "dev": true
     },
     "ansi-escapes": {
       "version": "3.2.0",
-      "resolved": "https://registry.npm.taobao.org/ansi-escapes/download/ansi-escapes-3.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.2.0.tgz",
       "integrity": "sha1-h4C5j/nb9WOBUtHx/lwde0RCl2s=",
       "dev": true
     },
     "ansi-html": {
       "version": "0.0.7",
-      "resolved": "https://registry.npm.taobao.org/ansi-html/download/ansi-html-0.0.7.tgz",
+      "resolved": "https://registry.npmjs.org/ansi-html/-/ansi-html-0.0.7.tgz",
       "integrity": "sha1-gTWEAhliqenm/QOflA0S9WynhZ4=",
       "dev": true
     },
     "ansi-regex": {
       "version": "4.1.0",
-      "resolved": "https://registry.npm.taobao.org/ansi-regex/download/ansi-regex-4.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
       "integrity": "sha1-i5+PCM8ay4Q3Vqg5yox+MWjFGZc=",
       "dev": true
     },
     "ansi-styles": {
       "version": "3.2.1",
-      "resolved": "https://registry.npm.taobao.org/ansi-styles/download/ansi-styles-3.2.1.tgz",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
       "integrity": "sha1-QfuyAkPlCxK+DwS43tvwdSDOhB0=",
       "dev": true,
       "requires": {
@@ -1739,13 +1739,13 @@
     },
     "any-promise": {
       "version": "1.3.0",
-      "resolved": "https://registry.npm.taobao.org/any-promise/download/any-promise-1.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/any-promise/-/any-promise-1.3.0.tgz",
       "integrity": "sha1-q8av7tzqUugJzcA3au0845Y10X8=",
       "dev": true
     },
     "anymatch": {
       "version": "2.0.0",
-      "resolved": "https://registry.npm.taobao.org/anymatch/download/anymatch-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-2.0.0.tgz",
       "integrity": "sha1-vLJLTzeTTZqnrBe0ra+J58du8us=",
       "dev": true,
       "requires": {
@@ -1755,7 +1755,7 @@
       "dependencies": {
         "normalize-path": {
           "version": "2.1.1",
-          "resolved": "https://registry.npm.taobao.org/normalize-path/download/normalize-path-2.1.1.tgz",
+          "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
           "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
           "dev": true,
           "requires": {
@@ -1766,19 +1766,19 @@
     },
     "aproba": {
       "version": "1.2.0",
-      "resolved": "https://registry.npm.taobao.org/aproba/download/aproba-1.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
       "integrity": "sha1-aALmJk79GMeQobDVF/DyYnvyyUo=",
       "dev": true
     },
     "arch": {
       "version": "2.1.1",
-      "resolved": "https://registry.npm.taobao.org/arch/download/arch-2.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/arch/-/arch-2.1.1.tgz",
       "integrity": "sha1-j1wnMao1owkpIhuwZA7tZRdeyE4=",
       "dev": true
     },
     "argparse": {
       "version": "1.0.10",
-      "resolved": "https://registry.npm.taobao.org/argparse/download/argparse-1.0.10.tgz",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
       "integrity": "sha1-vNZ5HqWuCXJeF+WtmIE0zUCz2RE=",
       "dev": true,
       "requires": {
@@ -1787,49 +1787,49 @@
     },
     "arr-diff": {
       "version": "4.0.0",
-      "resolved": "https://registry.npm.taobao.org/arr-diff/download/arr-diff-4.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
       "integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA=",
       "dev": true
     },
     "arr-flatten": {
       "version": "1.1.0",
-      "resolved": "https://registry.npm.taobao.org/arr-flatten/download/arr-flatten-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.1.0.tgz",
       "integrity": "sha1-NgSLv/TntH4TZkQxbJlmnqWukfE=",
       "dev": true
     },
     "arr-union": {
       "version": "3.1.0",
-      "resolved": "https://registry.npm.taobao.org/arr-union/download/arr-union-3.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/arr-union/-/arr-union-3.1.0.tgz",
       "integrity": "sha1-45sJrqne+Gao8gbiiK9jkZuuOcQ=",
       "dev": true
     },
     "array-filter": {
       "version": "0.0.1",
-      "resolved": "https://registry.npm.taobao.org/array-filter/download/array-filter-0.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/array-filter/-/array-filter-0.0.1.tgz",
       "integrity": "sha1-fajPLiZijtcygDWB/SH2fKzS7uw=",
       "dev": true
     },
     "array-flatten": {
       "version": "1.1.1",
-      "resolved": "https://registry.npm.taobao.org/array-flatten/download/array-flatten-1.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
       "integrity": "sha1-ml9pkFGx5wczKPKgCJaLZOopVdI=",
       "dev": true
     },
     "array-map": {
       "version": "0.0.0",
-      "resolved": "https://registry.npm.taobao.org/array-map/download/array-map-0.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/array-map/-/array-map-0.0.0.tgz",
       "integrity": "sha1-iKK6tz0c97zVwbEYoAP2b2ZfpmI=",
       "dev": true
     },
     "array-reduce": {
       "version": "0.0.0",
-      "resolved": "https://registry.npm.taobao.org/array-reduce/download/array-reduce-0.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/array-reduce/-/array-reduce-0.0.0.tgz",
       "integrity": "sha1-FziZ0//Rx9k4PkR5Ul2+J4yrXys=",
       "dev": true
     },
     "array-union": {
       "version": "1.0.2",
-      "resolved": "https://registry.npm.taobao.org/array-union/download/array-union-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/array-union/-/array-union-1.0.2.tgz",
       "integrity": "sha1-mjRBDk9OPaI96jdb5b5w8kd47Dk=",
       "dev": true,
       "requires": {
@@ -1838,19 +1838,19 @@
     },
     "array-uniq": {
       "version": "1.0.3",
-      "resolved": "https://registry.npm.taobao.org/array-uniq/download/array-uniq-1.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.3.tgz",
       "integrity": "sha1-r2rId6Jcx/dOBYiUdThY39sk/bY=",
       "dev": true
     },
     "array-unique": {
       "version": "0.3.2",
-      "resolved": "https://registry.npm.taobao.org/array-unique/download/array-unique-0.3.2.tgz",
+      "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
       "integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg=",
       "dev": true
     },
     "asn1": {
       "version": "0.2.4",
-      "resolved": "https://registry.npm.taobao.org/asn1/download/asn1-0.2.4.tgz",
+      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.4.tgz",
       "integrity": "sha1-jSR136tVO7M+d7VOWeiAu4ziMTY=",
       "dev": true,
       "requires": {
@@ -1859,7 +1859,7 @@
     },
     "asn1.js": {
       "version": "4.10.1",
-      "resolved": "https://registry.npm.taobao.org/asn1.js/download/asn1.js-4.10.1.tgz",
+      "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-4.10.1.tgz",
       "integrity": "sha1-ucK/WAXx5kqt7tbfOiv6+1pz9aA=",
       "dev": true,
       "requires": {
@@ -1870,7 +1870,7 @@
     },
     "assert": {
       "version": "1.5.0",
-      "resolved": "https://registry.npm.taobao.org/assert/download/assert-1.5.0.tgz",
+      "resolved": "https://registry.npmjs.org/assert/-/assert-1.5.0.tgz",
       "integrity": "sha1-VcEJqvbgrv2z3EtxJAxwv1dLGOs=",
       "dev": true,
       "requires": {
@@ -1880,13 +1880,13 @@
       "dependencies": {
         "inherits": {
           "version": "2.0.1",
-          "resolved": "https://registry.npm.taobao.org/inherits/download/inherits-2.0.1.tgz?cache=0&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Finherits%2Fdownload%2Finherits-2.0.1.tgz",
+          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
           "integrity": "sha1-sX0I0ya0Qj5Wjv9xn5GwscvfafE=",
           "dev": true
         },
         "util": {
           "version": "0.10.3",
-          "resolved": "https://registry.npm.taobao.org/util/download/util-0.10.3.tgz",
+          "resolved": "https://registry.npmjs.org/util/-/util-0.10.3.tgz",
           "integrity": "sha1-evsa/lCAUkZInj23/g7TeTNqwPk=",
           "dev": true,
           "requires": {
@@ -1897,55 +1897,55 @@
     },
     "assert-plus": {
       "version": "1.0.0",
-      "resolved": "https://registry.npm.taobao.org/assert-plus/download/assert-plus-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
       "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
       "dev": true
     },
     "assign-symbols": {
       "version": "1.0.0",
-      "resolved": "https://registry.npm.taobao.org/assign-symbols/download/assign-symbols-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/assign-symbols/-/assign-symbols-1.0.0.tgz",
       "integrity": "sha1-WWZ/QfrdTyDMvCu5a41Pf3jsA2c=",
       "dev": true
     },
     "astral-regex": {
       "version": "1.0.0",
-      "resolved": "https://registry.npm.taobao.org/astral-regex/download/astral-regex-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-1.0.0.tgz",
       "integrity": "sha1-bIw/uCfdQ+45GPJ7gngqt2WKb9k=",
       "dev": true
     },
     "async": {
       "version": "1.5.2",
-      "resolved": "https://registry.npm.taobao.org/async/download/async-1.5.2.tgz",
+      "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
       "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=",
       "dev": true
     },
     "async-each": {
       "version": "1.0.3",
-      "resolved": "https://registry.npm.taobao.org/async-each/download/async-each-1.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/async-each/-/async-each-1.0.3.tgz",
       "integrity": "sha1-tyfb+H12UWAvBvTUrDh/R9kbDL8=",
       "dev": true
     },
     "async-limiter": {
       "version": "1.0.1",
-      "resolved": "https://registry.npm.taobao.org/async-limiter/download/async-limiter-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/async-limiter/-/async-limiter-1.0.1.tgz",
       "integrity": "sha1-3TeelPDbgxCwgpH51kwyCXZmF/0=",
       "dev": true
     },
     "asynckit": {
       "version": "0.4.0",
-      "resolved": "https://registry.npm.taobao.org/asynckit/download/asynckit-0.4.0.tgz",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
       "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
       "dev": true
     },
     "atob": {
       "version": "2.1.2",
-      "resolved": "https://registry.npm.taobao.org/atob/download/atob-2.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/atob/-/atob-2.1.2.tgz",
       "integrity": "sha1-bZUX654DDSQ2ZmZR6GvZ9vE1M8k=",
       "dev": true
     },
     "autoprefixer": {
       "version": "9.6.1",
-      "resolved": "https://registry.npm.taobao.org/autoprefixer/download/autoprefixer-9.6.1.tgz",
+      "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-9.6.1.tgz",
       "integrity": "sha1-UZZ6AtLSMAuwGGbBYR7INI01Wkc=",
       "dev": true,
       "requires": {
@@ -1960,7 +1960,7 @@
       "dependencies": {
         "postcss-value-parser": {
           "version": "4.0.2",
-          "resolved": "https://registry.npm.taobao.org/postcss-value-parser/download/postcss-value-parser-4.0.2.tgz",
+          "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.0.2.tgz",
           "integrity": "sha1-SCKCwJpCcG0fyaBptz9E7Ag5Hck=",
           "dev": true
         }
@@ -1968,19 +1968,19 @@
     },
     "aws-sign2": {
       "version": "0.7.0",
-      "resolved": "https://registry.npm.taobao.org/aws-sign2/download/aws-sign2-0.7.0.tgz",
+      "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
       "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg=",
       "dev": true
     },
     "aws4": {
       "version": "1.8.0",
-      "resolved": "https://registry.npm.taobao.org/aws4/download/aws4-1.8.0.tgz",
+      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.8.0.tgz",
       "integrity": "sha1-8OAD2cqef1nHpQiUXXsu+aBKVC8=",
       "dev": true
     },
     "babel-code-frame": {
       "version": "6.26.0",
-      "resolved": "https://registry.npm.taobao.org/babel-code-frame/download/babel-code-frame-6.26.0.tgz",
+      "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.26.0.tgz",
       "integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
       "dev": true,
       "requires": {
@@ -1991,19 +1991,19 @@
       "dependencies": {
         "ansi-regex": {
           "version": "2.1.1",
-          "resolved": "https://registry.npm.taobao.org/ansi-regex/download/ansi-regex-2.1.1.tgz",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
           "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
           "dev": true
         },
         "ansi-styles": {
           "version": "2.2.1",
-          "resolved": "https://registry.npm.taobao.org/ansi-styles/download/ansi-styles-2.2.1.tgz",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
           "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
           "dev": true
         },
         "chalk": {
           "version": "1.1.3",
-          "resolved": "https://registry.npm.taobao.org/chalk/download/chalk-1.1.3.tgz",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "dev": true,
           "requires": {
@@ -2016,13 +2016,13 @@
         },
         "js-tokens": {
           "version": "3.0.2",
-          "resolved": "https://registry.npm.taobao.org/js-tokens/download/js-tokens-3.0.2.tgz",
+          "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
           "integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls=",
           "dev": true
         },
         "strip-ansi": {
           "version": "3.0.1",
-          "resolved": "https://registry.npm.taobao.org/strip-ansi/download/strip-ansi-3.0.1.tgz",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "dev": true,
           "requires": {
@@ -2031,7 +2031,7 @@
         },
         "supports-color": {
           "version": "2.0.0",
-          "resolved": "https://registry.npm.taobao.org/supports-color/download/supports-color-2.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
           "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
           "dev": true
         }
@@ -2039,7 +2039,7 @@
     },
     "babel-eslint": {
       "version": "10.0.2",
-      "resolved": "https://registry.npm.taobao.org/babel-eslint/download/babel-eslint-10.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/babel-eslint/-/babel-eslint-10.0.2.tgz",
       "integrity": "sha1-GC1awgRXn/CIFoSwQFYP3MFVhFY=",
       "dev": true,
       "requires": {
@@ -2053,7 +2053,7 @@
       "dependencies": {
         "eslint-scope": {
           "version": "3.7.1",
-          "resolved": "https://registry.npm.taobao.org/eslint-scope/download/eslint-scope-3.7.1.tgz?cache=0&sync_timestamp=1563679289211&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Feslint-scope%2Fdownload%2Feslint-scope-3.7.1.tgz",
+          "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-3.7.1.tgz",
           "integrity": "sha1-PWPD7f2gLgbgGkUq2IyqzHzctug=",
           "dev": true,
           "requires": {
@@ -2065,7 +2065,7 @@
     },
     "babel-loader": {
       "version": "8.0.6",
-      "resolved": "https://registry.npm.taobao.org/babel-loader/download/babel-loader-8.0.6.tgz",
+      "resolved": "https://registry.npmjs.org/babel-loader/-/babel-loader-8.0.6.tgz",
       "integrity": "sha1-4zvbbzYrA/S7FBoMIauHxQG3Dfs=",
       "dev": true,
       "requires": {
@@ -2077,7 +2077,7 @@
     },
     "babel-plugin-dynamic-import-node": {
       "version": "2.3.0",
-      "resolved": "https://registry.npm.taobao.org/babel-plugin-dynamic-import-node/download/babel-plugin-dynamic-import-node-2.3.0.tgz?cache=0&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fbabel-plugin-dynamic-import-node%2Fdownload%2Fbabel-plugin-dynamic-import-node-2.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/babel-plugin-dynamic-import-node/-/babel-plugin-dynamic-import-node-2.3.0.tgz",
       "integrity": "sha1-8A9Qe9qjw+P/bn5emNkKesq5b38=",
       "dev": true,
       "requires": {
@@ -2086,7 +2086,7 @@
     },
     "babel-plugin-module-resolver": {
       "version": "3.2.0",
-      "resolved": "https://registry.npm.taobao.org/babel-plugin-module-resolver/download/babel-plugin-module-resolver-3.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/babel-plugin-module-resolver/-/babel-plugin-module-resolver-3.2.0.tgz",
       "integrity": "sha1-3fpeMB47mqEthSqZefGLN4gf9ac=",
       "dev": true,
       "requires": {
@@ -2099,13 +2099,13 @@
     },
     "balanced-match": {
       "version": "1.0.0",
-      "resolved": "https://registry.npm.taobao.org/balanced-match/download/balanced-match-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
       "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
       "dev": true
     },
     "base": {
       "version": "0.11.2",
-      "resolved": "https://registry.npm.taobao.org/base/download/base-0.11.2.tgz",
+      "resolved": "https://registry.npmjs.org/base/-/base-0.11.2.tgz",
       "integrity": "sha1-e95c7RRbbVUakNuH+DxVi060io8=",
       "dev": true,
       "requires": {
@@ -2120,7 +2120,7 @@
       "dependencies": {
         "define-property": {
           "version": "1.0.0",
-          "resolved": "https://registry.npm.taobao.org/define-property/download/define-property-1.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
           "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
           "dev": true,
           "requires": {
@@ -2129,7 +2129,7 @@
         },
         "is-accessor-descriptor": {
           "version": "1.0.0",
-          "resolved": "https://registry.npm.taobao.org/is-accessor-descriptor/download/is-accessor-descriptor-1.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
           "integrity": "sha1-FpwvbT3x+ZJhgHI2XJsOofaHhlY=",
           "dev": true,
           "requires": {
@@ -2138,7 +2138,7 @@
         },
         "is-data-descriptor": {
           "version": "1.0.0",
-          "resolved": "https://registry.npm.taobao.org/is-data-descriptor/download/is-data-descriptor-1.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
           "integrity": "sha1-2Eh2Mh0Oet0DmQQGq7u9NrqSaMc=",
           "dev": true,
           "requires": {
@@ -2147,7 +2147,7 @@
         },
         "is-descriptor": {
           "version": "1.0.2",
-          "resolved": "https://registry.npm.taobao.org/is-descriptor/download/is-descriptor-1.0.2.tgz",
+          "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
           "integrity": "sha1-OxWXRqZmBLBPjIFSS6NlxfFNhuw=",
           "dev": true,
           "requires": {
@@ -2160,19 +2160,19 @@
     },
     "base64-js": {
       "version": "1.3.1",
-      "resolved": "https://registry.npm.taobao.org/base64-js/download/base64-js-1.3.1.tgz",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.3.1.tgz",
       "integrity": "sha1-WOzoy3XdB+ce0IxzarxfrE2/jfE=",
       "dev": true
     },
     "batch": {
       "version": "0.6.1",
-      "resolved": "https://registry.npm.taobao.org/batch/download/batch-0.6.1.tgz",
+      "resolved": "https://registry.npmjs.org/batch/-/batch-0.6.1.tgz",
       "integrity": "sha1-3DQxT05nkxgJP8dgJyUl+UvyXBY=",
       "dev": true
     },
     "bcrypt-pbkdf": {
       "version": "1.0.2",
-      "resolved": "https://registry.npm.taobao.org/bcrypt-pbkdf/download/bcrypt-pbkdf-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
       "integrity": "sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=",
       "dev": true,
       "requires": {
@@ -2181,7 +2181,7 @@
     },
     "bfj": {
       "version": "6.1.2",
-      "resolved": "https://registry.npm.taobao.org/bfj/download/bfj-6.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/bfj/-/bfj-6.1.2.tgz",
       "integrity": "sha1-MlyGGoIryzWKQceKM7jm4ght3n8=",
       "dev": true,
       "requires": {
@@ -2193,31 +2193,31 @@
     },
     "big.js": {
       "version": "5.2.2",
-      "resolved": "https://registry.npm.taobao.org/big.js/download/big.js-5.2.2.tgz",
+      "resolved": "https://registry.npmjs.org/big.js/-/big.js-5.2.2.tgz",
       "integrity": "sha1-ZfCvOC9Xi83HQr2cKB6cstd2gyg=",
       "dev": true
     },
     "binary-extensions": {
       "version": "1.13.1",
-      "resolved": "https://registry.npm.taobao.org/binary-extensions/download/binary-extensions-1.13.1.tgz",
+      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.13.1.tgz",
       "integrity": "sha1-WYr+VHVbKGilMw0q/51Ou1Mgm2U=",
       "dev": true
     },
     "bluebird": {
       "version": "3.5.5",
-      "resolved": "https://registry.npm.taobao.org/bluebird/download/bluebird-3.5.5.tgz",
+      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.5.tgz",
       "integrity": "sha1-qNCv1zJR7/u9X+OEp31zADwXpx8=",
       "dev": true
     },
     "bn.js": {
       "version": "4.11.8",
-      "resolved": "https://registry.npm.taobao.org/bn.js/download/bn.js-4.11.8.tgz",
+      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.8.tgz",
       "integrity": "sha1-LN4J617jQfSEdGuwMJsyU7GxRC8=",
       "dev": true
     },
     "body-parser": {
       "version": "1.19.0",
-      "resolved": "https://registry.npm.taobao.org/body-parser/download/body-parser-1.19.0.tgz",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.19.0.tgz",
       "integrity": "sha1-lrJwnlfJxOCab9Zqj9l5hE9p8Io=",
       "dev": true,
       "requires": {
@@ -2235,7 +2235,7 @@
       "dependencies": {
         "debug": {
           "version": "2.6.9",
-          "resolved": "https://registry.npm.taobao.org/debug/download/debug-2.6.9.tgz",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
           "integrity": "sha1-XRKFFd8TT/Mn6QpMk/Tgd6U2NB8=",
           "dev": true,
           "requires": {
@@ -2244,13 +2244,13 @@
         },
         "ms": {
           "version": "2.0.0",
-          "resolved": "https://registry.npm.taobao.org/ms/download/ms-2.0.0.tgz?cache=0&sync_timestamp=1559842528856&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fms%2Fdownload%2Fms-2.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
           "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
           "dev": true
         },
         "qs": {
           "version": "6.7.0",
-          "resolved": "https://registry.npm.taobao.org/qs/download/qs-6.7.0.tgz",
+          "resolved": "https://registry.npmjs.org/qs/-/qs-6.7.0.tgz",
           "integrity": "sha1-QdwaAV49WB8WIXdr4xr7KHapsbw=",
           "dev": true
         }
@@ -2258,7 +2258,7 @@
     },
     "bonjour": {
       "version": "3.5.0",
-      "resolved": "https://registry.npm.taobao.org/bonjour/download/bonjour-3.5.0.tgz",
+      "resolved": "https://registry.npmjs.org/bonjour/-/bonjour-3.5.0.tgz",
       "integrity": "sha1-jokKGD2O6aI5OzhExpGkK897yfU=",
       "dev": true,
       "requires": {
@@ -2272,7 +2272,7 @@
       "dependencies": {
         "array-flatten": {
           "version": "2.1.2",
-          "resolved": "https://registry.npm.taobao.org/array-flatten/download/array-flatten-2.1.2.tgz",
+          "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-2.1.2.tgz",
           "integrity": "sha1-JO+AoowaiTYX4hSbDG0NeIKTsJk=",
           "dev": true
         }
@@ -2280,13 +2280,13 @@
     },
     "boolbase": {
       "version": "1.0.0",
-      "resolved": "https://registry.npm.taobao.org/boolbase/download/boolbase-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
       "integrity": "sha1-aN/1++YMUes3cl6p4+0xDcwed24=",
       "dev": true
     },
     "brace-expansion": {
       "version": "1.1.11",
-      "resolved": "https://registry.npm.taobao.org/brace-expansion/download/brace-expansion-1.1.11.tgz",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
       "integrity": "sha1-PH/L9SnYcibz0vUrlm/1Jx60Qd0=",
       "dev": true,
       "requires": {
@@ -2296,7 +2296,7 @@
     },
     "braces": {
       "version": "2.3.2",
-      "resolved": "https://registry.npm.taobao.org/braces/download/braces-2.3.2.tgz",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
       "integrity": "sha1-WXn9PxTNUxVl5fot8av/8d+u5yk=",
       "dev": true,
       "requires": {
@@ -2314,7 +2314,7 @@
       "dependencies": {
         "extend-shallow": {
           "version": "2.0.1",
-          "resolved": "https://registry.npm.taobao.org/extend-shallow/download/extend-shallow-2.0.1.tgz",
+          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
           "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
           "dev": true,
           "requires": {
@@ -2325,13 +2325,13 @@
     },
     "brorand": {
       "version": "1.1.0",
-      "resolved": "https://registry.npm.taobao.org/brorand/download/brorand-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/brorand/-/brorand-1.1.0.tgz",
       "integrity": "sha1-EsJe/kCkXjwyPrhnWgoM5XsiNx8=",
       "dev": true
     },
     "browserify-aes": {
       "version": "1.2.0",
-      "resolved": "https://registry.npm.taobao.org/browserify-aes/download/browserify-aes-1.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-1.2.0.tgz",
       "integrity": "sha1-Mmc0ZC9APavDADIJhTu3CtQo70g=",
       "dev": true,
       "requires": {
@@ -2345,7 +2345,7 @@
     },
     "browserify-cipher": {
       "version": "1.0.1",
-      "resolved": "https://registry.npm.taobao.org/browserify-cipher/download/browserify-cipher-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/browserify-cipher/-/browserify-cipher-1.0.1.tgz",
       "integrity": "sha1-jWR0wbhwv9q807z8wZNKEOlPFfA=",
       "dev": true,
       "requires": {
@@ -2356,7 +2356,7 @@
     },
     "browserify-des": {
       "version": "1.0.2",
-      "resolved": "https://registry.npm.taobao.org/browserify-des/download/browserify-des-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/browserify-des/-/browserify-des-1.0.2.tgz",
       "integrity": "sha1-OvTx9Zg5QDVy8cZiBDdfen9wPpw=",
       "dev": true,
       "requires": {
@@ -2368,7 +2368,7 @@
     },
     "browserify-rsa": {
       "version": "4.0.1",
-      "resolved": "https://registry.npm.taobao.org/browserify-rsa/download/browserify-rsa-4.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/browserify-rsa/-/browserify-rsa-4.0.1.tgz",
       "integrity": "sha1-IeCr+vbyApzy+vsTNWenAdQTVSQ=",
       "dev": true,
       "requires": {
@@ -2378,7 +2378,7 @@
     },
     "browserify-sign": {
       "version": "4.0.4",
-      "resolved": "https://registry.npm.taobao.org/browserify-sign/download/browserify-sign-4.0.4.tgz",
+      "resolved": "https://registry.npmjs.org/browserify-sign/-/browserify-sign-4.0.4.tgz",
       "integrity": "sha1-qk62jl17ZYuqa/alfmMMvXqT0pg=",
       "dev": true,
       "requires": {
@@ -2393,7 +2393,7 @@
     },
     "browserify-zlib": {
       "version": "0.2.0",
-      "resolved": "https://registry.npm.taobao.org/browserify-zlib/download/browserify-zlib-0.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/browserify-zlib/-/browserify-zlib-0.2.0.tgz",
       "integrity": "sha1-KGlFnZqjviRf6P4sofRuLn9U1z8=",
       "dev": true,
       "requires": {
@@ -2402,7 +2402,7 @@
     },
     "browserslist": {
       "version": "4.6.6",
-      "resolved": "https://registry.npm.taobao.org/browserslist/download/browserslist-4.6.6.tgz",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.6.6.tgz",
       "integrity": "sha1-bkv0Z83lILydvfN0fa+gNTHOxFM=",
       "dev": true,
       "requires": {
@@ -2413,7 +2413,7 @@
     },
     "buffer": {
       "version": "4.9.1",
-      "resolved": "https://registry.npm.taobao.org/buffer/download/buffer-4.9.1.tgz",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-4.9.1.tgz",
       "integrity": "sha1-bRu2AbB6TvztlwlBMgkwJ8lbwpg=",
       "dev": true,
       "requires": {
@@ -2424,37 +2424,37 @@
     },
     "buffer-from": {
       "version": "1.1.1",
-      "resolved": "https://registry.npm.taobao.org/buffer-from/download/buffer-from-1.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
       "integrity": "sha1-MnE7wCj3XAL9txDXx7zsHyxgcO8=",
       "dev": true
     },
     "buffer-indexof": {
       "version": "1.1.1",
-      "resolved": "https://registry.npm.taobao.org/buffer-indexof/download/buffer-indexof-1.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/buffer-indexof/-/buffer-indexof-1.1.1.tgz",
       "integrity": "sha1-Uvq8xqYG0aADAoAmSO9o9jnaJow=",
       "dev": true
     },
     "buffer-xor": {
       "version": "1.0.3",
-      "resolved": "https://registry.npm.taobao.org/buffer-xor/download/buffer-xor-1.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/buffer-xor/-/buffer-xor-1.0.3.tgz",
       "integrity": "sha1-JuYe0UIvtw3ULm42cp7VHYVf6Nk=",
       "dev": true
     },
     "builtin-status-codes": {
       "version": "3.0.0",
-      "resolved": "https://registry.npm.taobao.org/builtin-status-codes/download/builtin-status-codes-3.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/builtin-status-codes/-/builtin-status-codes-3.0.0.tgz",
       "integrity": "sha1-hZgoeOIbmOHGZCXgPQF0eI9Wnug=",
       "dev": true
     },
     "bytes": {
       "version": "3.1.0",
-      "resolved": "https://registry.npm.taobao.org/bytes/download/bytes-3.1.0.tgz?cache=0&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fbytes%2Fdownload%2Fbytes-3.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.0.tgz",
       "integrity": "sha1-9s95M6Ng4FiPqf3oVlHNx/gF0fY=",
       "dev": true
     },
     "cacache": {
       "version": "12.0.2",
-      "resolved": "https://registry.npm.taobao.org/cacache/download/cacache-12.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/cacache/-/cacache-12.0.2.tgz",
       "integrity": "sha1-jbAyBeNgiaPfaVTGbOklQUQaxGw=",
       "dev": true,
       "requires": {
@@ -2477,7 +2477,7 @@
     },
     "cache-base": {
       "version": "1.0.1",
-      "resolved": "https://registry.npm.taobao.org/cache-base/download/cache-base-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/cache-base/-/cache-base-1.0.1.tgz",
       "integrity": "sha1-Cn9GQWgxyLZi7jb+TnxZ129marI=",
       "dev": true,
       "requires": {
@@ -2494,7 +2494,7 @@
     },
     "cache-loader": {
       "version": "2.0.1",
-      "resolved": "https://registry.npm.taobao.org/cache-loader/download/cache-loader-2.0.1.tgz?cache=0&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fcache-loader%2Fdownload%2Fcache-loader-2.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/cache-loader/-/cache-loader-2.0.1.tgz",
       "integrity": "sha1-V1j0GmLXwjlB48PHAW5vrrA6ywc=",
       "dev": true,
       "requires": {
@@ -2507,7 +2507,7 @@
       "dependencies": {
         "schema-utils": {
           "version": "1.0.0",
-          "resolved": "https://registry.npm.taobao.org/schema-utils/download/schema-utils-1.0.0.tgz?cache=0&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fschema-utils%2Fdownload%2Fschema-utils-1.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-1.0.0.tgz",
           "integrity": "sha1-C3mpMgTXtgDUsoUNH2bCo0lRx3A=",
           "dev": true,
           "requires": {
@@ -2520,13 +2520,13 @@
     },
     "call-me-maybe": {
       "version": "1.0.1",
-      "resolved": "https://registry.npm.taobao.org/call-me-maybe/download/call-me-maybe-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/call-me-maybe/-/call-me-maybe-1.0.1.tgz",
       "integrity": "sha1-JtII6onje1y95gJQoV8DHBak1ms=",
       "dev": true
     },
     "caller-callsite": {
       "version": "2.0.0",
-      "resolved": "https://registry.npm.taobao.org/caller-callsite/download/caller-callsite-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/caller-callsite/-/caller-callsite-2.0.0.tgz",
       "integrity": "sha1-hH4PzgoiN1CpoCfFSzNzGtMVQTQ=",
       "dev": true,
       "requires": {
@@ -2535,7 +2535,7 @@
       "dependencies": {
         "callsites": {
           "version": "2.0.0",
-          "resolved": "https://registry.npm.taobao.org/callsites/download/callsites-2.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/callsites/-/callsites-2.0.0.tgz",
           "integrity": "sha1-BuuE8A7qQT2oav/vrL/7Ngk7PFA=",
           "dev": true
         }
@@ -2543,7 +2543,7 @@
     },
     "caller-path": {
       "version": "0.1.0",
-      "resolved": "https://registry.npm.taobao.org/caller-path/download/caller-path-0.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/caller-path/-/caller-path-0.1.0.tgz",
       "integrity": "sha1-lAhe9jWB7NPaqSREqP6U6CV3dR8=",
       "dev": true,
       "optional": true,
@@ -2553,14 +2553,14 @@
     },
     "callsites": {
       "version": "0.2.0",
-      "resolved": "https://registry.npm.taobao.org/callsites/download/callsites-0.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/callsites/-/callsites-0.2.0.tgz",
       "integrity": "sha1-r6uWJikQp/M8GaV3WCXGnzTjUMo=",
       "dev": true,
       "optional": true
     },
     "camel-case": {
       "version": "3.0.0",
-      "resolved": "https://registry.npm.taobao.org/camel-case/download/camel-case-3.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/camel-case/-/camel-case-3.0.0.tgz",
       "integrity": "sha1-yjw2iKTpzzpM2nd9xNy8cTJJz3M=",
       "dev": true,
       "requires": {
@@ -2570,13 +2570,13 @@
     },
     "camelcase": {
       "version": "5.3.1",
-      "resolved": "https://registry.npm.taobao.org/camelcase/download/camelcase-5.3.1.tgz",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
       "integrity": "sha1-48mzFWnhBoEd8kL3FXJaH0xJQyA=",
       "dev": true
     },
     "caniuse-api": {
       "version": "3.0.0",
-      "resolved": "https://registry.npm.taobao.org/caniuse-api/download/caniuse-api-3.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/caniuse-api/-/caniuse-api-3.0.0.tgz",
       "integrity": "sha1-Xk2Q4idJYdRikZl99Znj7QCO5MA=",
       "dev": true,
       "requires": {
@@ -2588,25 +2588,25 @@
     },
     "caniuse-lite": {
       "version": "1.0.30000989",
-      "resolved": "https://registry.npm.taobao.org/caniuse-lite/download/caniuse-lite-1.0.30000989.tgz",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000989.tgz",
       "integrity": "sha1-uRk+KTzPfkQmxSRRNLjypWwKxLk=",
       "dev": true
     },
     "case-sensitive-paths-webpack-plugin": {
       "version": "2.2.0",
-      "resolved": "https://registry.npm.taobao.org/case-sensitive-paths-webpack-plugin/download/case-sensitive-paths-webpack-plugin-2.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/case-sensitive-paths-webpack-plugin/-/case-sensitive-paths-webpack-plugin-2.2.0.tgz",
       "integrity": "sha1-M3HvY2XvnCX6S4HBas4OnH3FjD4=",
       "dev": true
     },
     "caseless": {
       "version": "0.12.0",
-      "resolved": "https://registry.npm.taobao.org/caseless/download/caseless-0.12.0.tgz",
+      "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
       "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=",
       "dev": true
     },
     "chalk": {
       "version": "2.4.2",
-      "resolved": "https://registry.npm.taobao.org/chalk/download/chalk-2.4.2.tgz",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
       "integrity": "sha1-zUJUFnelQzPPVBpJEIwUMrRMlCQ=",
       "dev": true,
       "requires": {
@@ -2617,20 +2617,20 @@
     },
     "chardet": {
       "version": "0.4.2",
-      "resolved": "https://registry.npm.taobao.org/chardet/download/chardet-0.4.2.tgz",
+      "resolved": "https://registry.npmjs.org/chardet/-/chardet-0.4.2.tgz",
       "integrity": "sha1-tUc7M9yXxCTl2Y3IfVXU2KKci/I=",
       "dev": true,
       "optional": true
     },
     "check-types": {
       "version": "8.0.3",
-      "resolved": "https://registry.npm.taobao.org/check-types/download/check-types-8.0.3.tgz?cache=0&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fcheck-types%2Fdownload%2Fcheck-types-8.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/check-types/-/check-types-8.0.3.tgz",
       "integrity": "sha1-M1bMoZyIlUTy16le1JzlCKDs9VI=",
       "dev": true
     },
     "chokidar": {
       "version": "2.1.6",
-      "resolved": "https://registry.npm.taobao.org/chokidar/download/chokidar-2.1.6.tgz",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-2.1.6.tgz",
       "integrity": "sha1-tsrWU6kp4kTOioNCRBZNJB+pVMU=",
       "dev": true,
       "requires": {
@@ -2650,13 +2650,13 @@
     },
     "chownr": {
       "version": "1.1.2",
-      "resolved": "https://registry.npm.taobao.org/chownr/download/chownr-1.1.2.tgz?cache=0&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fchownr%2Fdownload%2Fchownr-1.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.2.tgz",
       "integrity": "sha1-oY8eCyacimpdPIbrKYvrFMPde/Y=",
       "dev": true
     },
     "chrome-trace-event": {
       "version": "1.0.2",
-      "resolved": "https://registry.npm.taobao.org/chrome-trace-event/download/chrome-trace-event-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/chrome-trace-event/-/chrome-trace-event-1.0.2.tgz",
       "integrity": "sha1-I0CQ7pfH1K0aLEvq4nUF3v/GCKQ=",
       "dev": true,
       "requires": {
@@ -2665,13 +2665,13 @@
     },
     "ci-info": {
       "version": "1.6.0",
-      "resolved": "https://registry.npm.taobao.org/ci-info/download/ci-info-1.6.0.tgz",
+      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-1.6.0.tgz",
       "integrity": "sha1-LKINu5zrMtRSSmgzAzE/AwSx5Jc=",
       "dev": true
     },
     "cipher-base": {
       "version": "1.0.4",
-      "resolved": "https://registry.npm.taobao.org/cipher-base/download/cipher-base-1.0.4.tgz",
+      "resolved": "https://registry.npmjs.org/cipher-base/-/cipher-base-1.0.4.tgz",
       "integrity": "sha1-h2Dk7MJy9MNjUy+SbYdKriwTl94=",
       "dev": true,
       "requires": {
@@ -2681,14 +2681,14 @@
     },
     "circular-json": {
       "version": "0.3.3",
-      "resolved": "https://registry.npm.taobao.org/circular-json/download/circular-json-0.3.3.tgz",
+      "resolved": "https://registry.npmjs.org/circular-json/-/circular-json-0.3.3.tgz",
       "integrity": "sha1-gVyZ6oT2gJUp0vRXkb34JxE1LWY=",
       "dev": true,
       "optional": true
     },
     "class-utils": {
       "version": "0.3.6",
-      "resolved": "https://registry.npm.taobao.org/class-utils/download/class-utils-0.3.6.tgz",
+      "resolved": "https://registry.npmjs.org/class-utils/-/class-utils-0.3.6.tgz",
       "integrity": "sha1-+TNprouafOAv1B+q0MqDAzGQxGM=",
       "dev": true,
       "requires": {
@@ -2700,7 +2700,7 @@
       "dependencies": {
         "define-property": {
           "version": "0.2.5",
-          "resolved": "https://registry.npm.taobao.org/define-property/download/define-property-0.2.5.tgz",
+          "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
           "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
           "dev": true,
           "requires": {
@@ -2711,7 +2711,7 @@
     },
     "clean-css": {
       "version": "4.2.1",
-      "resolved": "https://registry.npm.taobao.org/clean-css/download/clean-css-4.2.1.tgz",
+      "resolved": "https://registry.npmjs.org/clean-css/-/clean-css-4.2.1.tgz",
       "integrity": "sha1-LUEe92uFabbQyEBo2r6FsKpeXBc=",
       "dev": true,
       "requires": {
@@ -2720,7 +2720,7 @@
       "dependencies": {
         "source-map": {
           "version": "0.6.1",
-          "resolved": "https://registry.npm.taobao.org/source-map/download/source-map-0.6.1.tgz",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
           "integrity": "sha1-dHIq8y6WFOnCh6jQu95IteLxomM=",
           "dev": true
         }
@@ -2728,7 +2728,7 @@
     },
     "cli-cursor": {
       "version": "2.1.0",
-      "resolved": "https://registry.npm.taobao.org/cli-cursor/download/cli-cursor-2.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-2.1.0.tgz",
       "integrity": "sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=",
       "dev": true,
       "requires": {
@@ -2737,7 +2737,7 @@
     },
     "cli-highlight": {
       "version": "2.1.1",
-      "resolved": "https://registry.npm.taobao.org/cli-highlight/download/cli-highlight-2.1.1.tgz?cache=0&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fcli-highlight%2Fdownload%2Fcli-highlight-2.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/cli-highlight/-/cli-highlight-2.1.1.tgz",
       "integrity": "sha1-IYAiPVFhixEvRQnPluSmx1Cwfpc=",
       "dev": true,
       "requires": {
@@ -2750,19 +2750,19 @@
     },
     "cli-spinners": {
       "version": "2.2.0",
-      "resolved": "https://registry.npm.taobao.org/cli-spinners/download/cli-spinners-2.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-2.2.0.tgz",
       "integrity": "sha1-6LmI2SBsaSMC2O6DTnqFwBRNj3c=",
       "dev": true
     },
     "cli-width": {
       "version": "2.2.0",
-      "resolved": "https://registry.npm.taobao.org/cli-width/download/cli-width-2.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-2.2.0.tgz",
       "integrity": "sha1-/xnt6Kml5XkyQUewwR8PvLq+1jk=",
       "dev": true
     },
     "clipboardy": {
       "version": "2.1.0",
-      "resolved": "https://registry.npm.taobao.org/clipboardy/download/clipboardy-2.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/clipboardy/-/clipboardy-2.1.0.tgz",
       "integrity": "sha1-ASOgyPrJLyVtxWM14LuL6XpJCaU=",
       "dev": true,
       "requires": {
@@ -2772,7 +2772,7 @@
     },
     "cliui": {
       "version": "5.0.0",
-      "resolved": "https://registry.npm.taobao.org/cliui/download/cliui-5.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-5.0.0.tgz",
       "integrity": "sha1-3u/P2y6AB4SqNPRvoI4GhRx7u8U=",
       "dev": true,
       "requires": {
@@ -2783,7 +2783,7 @@
       "dependencies": {
         "string-width": {
           "version": "3.1.0",
-          "resolved": "https://registry.npm.taobao.org/string-width/download/string-width-3.1.0.tgz",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
           "integrity": "sha1-InZ74htirxCBV0MG9prFG2IgOWE=",
           "dev": true,
           "requires": {
@@ -2796,13 +2796,13 @@
     },
     "clone": {
       "version": "1.0.4",
-      "resolved": "https://registry.npm.taobao.org/clone/download/clone-1.0.4.tgz?cache=0&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fclone%2Fdownload%2Fclone-1.0.4.tgz",
+      "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.4.tgz",
       "integrity": "sha1-2jCcwmPfFZlMaIypAheco8fNfH4=",
       "dev": true
     },
     "clone-deep": {
       "version": "4.0.1",
-      "resolved": "https://registry.npm.taobao.org/clone-deep/download/clone-deep-4.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/clone-deep/-/clone-deep-4.0.1.tgz",
       "integrity": "sha1-wZ/Zvbv4WUK0/ZechNz31fB8I4c=",
       "dev": true,
       "requires": {
@@ -2813,13 +2813,13 @@
     },
     "co": {
       "version": "4.6.0",
-      "resolved": "https://registry.npm.taobao.org/co/download/co-4.6.0.tgz",
+      "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
       "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=",
       "dev": true
     },
     "coa": {
       "version": "2.0.2",
-      "resolved": "https://registry.npm.taobao.org/coa/download/coa-2.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/coa/-/coa-2.0.2.tgz",
       "integrity": "sha1-Q/bCEVG07yv1cYfbDXPeIp4+fsM=",
       "dev": true,
       "requires": {
@@ -2830,13 +2830,13 @@
     },
     "code-point-at": {
       "version": "1.1.0",
-      "resolved": "https://registry.npm.taobao.org/code-point-at/download/code-point-at-1.1.0.tgz?cache=0&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fcode-point-at%2Fdownload%2Fcode-point-at-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
       "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
       "dev": true
     },
     "collection-visit": {
       "version": "1.0.0",
-      "resolved": "https://registry.npm.taobao.org/collection-visit/download/collection-visit-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/collection-visit/-/collection-visit-1.0.0.tgz",
       "integrity": "sha1-S8A3PBZLwykbTTaMgpzxqApZ3KA=",
       "dev": true,
       "requires": {
@@ -2846,7 +2846,7 @@
     },
     "color": {
       "version": "3.1.2",
-      "resolved": "https://registry.npm.taobao.org/color/download/color-3.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/color/-/color-3.1.2.tgz",
       "integrity": "sha1-aBSOf4XUGtdknF+oyBBvCY0inhA=",
       "dev": true,
       "requires": {
@@ -2856,7 +2856,7 @@
     },
     "color-convert": {
       "version": "1.9.3",
-      "resolved": "https://registry.npm.taobao.org/color-convert/download/color-convert-1.9.3.tgz",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
       "integrity": "sha1-u3GFBpDh8TZWfeYp0tVHHe2kweg=",
       "dev": true,
       "requires": {
@@ -2865,13 +2865,13 @@
     },
     "color-name": {
       "version": "1.1.3",
-      "resolved": "https://registry.npm.taobao.org/color-name/download/color-name-1.1.3.tgz",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
       "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
       "dev": true
     },
     "color-string": {
       "version": "1.5.3",
-      "resolved": "https://registry.npm.taobao.org/color-string/download/color-string-1.5.3.tgz?cache=0&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fcolor-string%2Fdownload%2Fcolor-string-1.5.3.tgz",
+      "resolved": "https://registry.npmjs.org/color-string/-/color-string-1.5.3.tgz",
       "integrity": "sha1-ybvF8BtYtUkvPWhXRZy2WQziBMw=",
       "dev": true,
       "requires": {
@@ -2881,7 +2881,7 @@
     },
     "combined-stream": {
       "version": "1.0.8",
-      "resolved": "https://registry.npm.taobao.org/combined-stream/download/combined-stream-1.0.8.tgz",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
       "integrity": "sha1-w9RaizT9cwYxoRCoolIGgrMdWn8=",
       "dev": true,
       "requires": {
@@ -2890,25 +2890,25 @@
     },
     "commander": {
       "version": "2.20.0",
-      "resolved": "https://registry.npm.taobao.org/commander/download/commander-2.20.0.tgz?cache=0&sync_timestamp=1565398176321&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fcommander%2Fdownload%2Fcommander-2.20.0.tgz",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.0.tgz",
       "integrity": "sha1-1YuytcHuj4ew00ACfp6U4iLFpCI=",
       "dev": true
     },
     "commondir": {
       "version": "1.0.1",
-      "resolved": "https://registry.npm.taobao.org/commondir/download/commondir-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
       "integrity": "sha1-3dgA2gxmEnOTzKWVDqloo6rxJTs=",
       "dev": true
     },
     "component-emitter": {
       "version": "1.3.0",
-      "resolved": "https://registry.npm.taobao.org/component-emitter/download/component-emitter-1.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.3.0.tgz",
       "integrity": "sha1-FuQHD7qK4ptnnyIVhT7hgasuq8A=",
       "dev": true
     },
     "compressible": {
       "version": "2.0.17",
-      "resolved": "https://registry.npm.taobao.org/compressible/download/compressible-2.0.17.tgz",
+      "resolved": "https://registry.npmjs.org/compressible/-/compressible-2.0.17.tgz",
       "integrity": "sha1-bowQihatWDhKl386SCyiC/8vOME=",
       "dev": true,
       "requires": {
@@ -2917,7 +2917,7 @@
     },
     "compression": {
       "version": "1.7.4",
-      "resolved": "https://registry.npm.taobao.org/compression/download/compression-1.7.4.tgz",
+      "resolved": "https://registry.npmjs.org/compression/-/compression-1.7.4.tgz",
       "integrity": "sha1-lVI+/xcMpXwpoMpB5v4TH0Hlu48=",
       "dev": true,
       "requires": {
@@ -2932,13 +2932,13 @@
       "dependencies": {
         "bytes": {
           "version": "3.0.0",
-          "resolved": "https://registry.npm.taobao.org/bytes/download/bytes-3.0.0.tgz?cache=0&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fbytes%2Fdownload%2Fbytes-3.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.0.0.tgz",
           "integrity": "sha1-0ygVQE1olpn4Wk6k+odV3ROpYEg=",
           "dev": true
         },
         "debug": {
           "version": "2.6.9",
-          "resolved": "https://registry.npm.taobao.org/debug/download/debug-2.6.9.tgz",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
           "integrity": "sha1-XRKFFd8TT/Mn6QpMk/Tgd6U2NB8=",
           "dev": true,
           "requires": {
@@ -2947,7 +2947,7 @@
         },
         "ms": {
           "version": "2.0.0",
-          "resolved": "https://registry.npm.taobao.org/ms/download/ms-2.0.0.tgz?cache=0&sync_timestamp=1559842528856&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fms%2Fdownload%2Fms-2.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
           "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
           "dev": true
         }
@@ -2955,13 +2955,13 @@
     },
     "concat-map": {
       "version": "0.0.1",
-      "resolved": "https://registry.npm.taobao.org/concat-map/download/concat-map-0.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
       "dev": true
     },
     "concat-stream": {
       "version": "1.6.2",
-      "resolved": "https://registry.npm.taobao.org/concat-stream/download/concat-stream-1.6.2.tgz",
+      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz",
       "integrity": "sha1-kEvfGUzTEi/Gdcd/xKw9T/D9GjQ=",
       "dev": true,
       "requires": {
@@ -2973,13 +2973,13 @@
     },
     "connect-history-api-fallback": {
       "version": "1.6.0",
-      "resolved": "https://registry.npm.taobao.org/connect-history-api-fallback/download/connect-history-api-fallback-1.6.0.tgz",
+      "resolved": "https://registry.npmjs.org/connect-history-api-fallback/-/connect-history-api-fallback-1.6.0.tgz",
       "integrity": "sha1-izIIk1kwjRERFdgcrT/Oq4iPl7w=",
       "dev": true
     },
     "console-browserify": {
       "version": "1.1.0",
-      "resolved": "https://registry.npm.taobao.org/console-browserify/download/console-browserify-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/console-browserify/-/console-browserify-1.1.0.tgz",
       "integrity": "sha1-8CQcRXMKn8YyOyBtvzjtx0HQuxA=",
       "dev": true,
       "requires": {
@@ -2988,7 +2988,7 @@
     },
     "consolidate": {
       "version": "0.15.1",
-      "resolved": "https://registry.npm.taobao.org/consolidate/download/consolidate-0.15.1.tgz",
+      "resolved": "https://registry.npmjs.org/consolidate/-/consolidate-0.15.1.tgz",
       "integrity": "sha1-IasEMjXHGgfUXZqtmFk7DbpWurc=",
       "dev": true,
       "requires": {
@@ -2997,13 +2997,13 @@
     },
     "constants-browserify": {
       "version": "1.0.0",
-      "resolved": "https://registry.npm.taobao.org/constants-browserify/download/constants-browserify-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/constants-browserify/-/constants-browserify-1.0.0.tgz",
       "integrity": "sha1-wguW2MYXdIqvHBYCF2DNJ/y4y3U=",
       "dev": true
     },
     "content-disposition": {
       "version": "0.5.3",
-      "resolved": "https://registry.npm.taobao.org/content-disposition/download/content-disposition-0.5.3.tgz",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.3.tgz",
       "integrity": "sha1-4TDK9+cnkIfFYWwgB9BIVpiYT70=",
       "dev": true,
       "requires": {
@@ -3012,13 +3012,13 @@
     },
     "content-type": {
       "version": "1.0.4",
-      "resolved": "https://registry.npm.taobao.org/content-type/download/content-type-1.0.4.tgz",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.4.tgz",
       "integrity": "sha1-4TjMdeBAxyexlm/l5fjJruJW/js=",
       "dev": true
     },
     "convert-source-map": {
       "version": "1.6.0",
-      "resolved": "https://registry.npm.taobao.org/convert-source-map/download/convert-source-map-1.6.0.tgz",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.6.0.tgz",
       "integrity": "sha1-UbU3qMQ+DwTewZk7/83VBOdYrCA=",
       "dev": true,
       "requires": {
@@ -3027,19 +3027,19 @@
     },
     "cookie": {
       "version": "0.4.0",
-      "resolved": "https://registry.npm.taobao.org/cookie/download/cookie-0.4.0.tgz",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.0.tgz",
       "integrity": "sha1-vrQ35wIrO21JAZ0IhmUwPr6cFLo=",
       "dev": true
     },
     "cookie-signature": {
       "version": "1.0.6",
-      "resolved": "https://registry.npm.taobao.org/cookie-signature/download/cookie-signature-1.0.6.tgz",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
       "integrity": "sha1-4wOogrNCzD7oylE6eZmXNNqzriw=",
       "dev": true
     },
     "copy-concurrently": {
       "version": "1.0.5",
-      "resolved": "https://registry.npm.taobao.org/copy-concurrently/download/copy-concurrently-1.0.5.tgz",
+      "resolved": "https://registry.npmjs.org/copy-concurrently/-/copy-concurrently-1.0.5.tgz",
       "integrity": "sha1-kilzmMrjSTf8r9bsgTnBgFHwteA=",
       "dev": true,
       "requires": {
@@ -3053,13 +3053,13 @@
     },
     "copy-descriptor": {
       "version": "0.1.1",
-      "resolved": "https://registry.npm.taobao.org/copy-descriptor/download/copy-descriptor-0.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/copy-descriptor/-/copy-descriptor-0.1.1.tgz",
       "integrity": "sha1-Z29us8OZl8LuGsOpJP1hJHSPV40=",
       "dev": true
     },
     "copy-webpack-plugin": {
       "version": "4.6.0",
-      "resolved": "https://registry.npm.taobao.org/copy-webpack-plugin/download/copy-webpack-plugin-4.6.0.tgz",
+      "resolved": "https://registry.npmjs.org/copy-webpack-plugin/-/copy-webpack-plugin-4.6.0.tgz",
       "integrity": "sha1-5/QN2KaEd9QF3Rt6hUquMksVi64=",
       "dev": true,
       "requires": {
@@ -3075,7 +3075,7 @@
       "dependencies": {
         "cacache": {
           "version": "10.0.4",
-          "resolved": "https://registry.npm.taobao.org/cacache/download/cacache-10.0.4.tgz",
+          "resolved": "https://registry.npmjs.org/cacache/-/cacache-10.0.4.tgz",
           "integrity": "sha1-ZFI2eZnv+dQYiu/ZoU6dfGomNGA=",
           "dev": true,
           "requires": {
@@ -3096,7 +3096,7 @@
         },
         "find-cache-dir": {
           "version": "1.0.0",
-          "resolved": "https://registry.npm.taobao.org/find-cache-dir/download/find-cache-dir-1.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-1.0.0.tgz",
           "integrity": "sha1-kojj6ePMN0hxfTnq3hfPcfww7m8=",
           "dev": true,
           "requires": {
@@ -3107,7 +3107,7 @@
         },
         "globby": {
           "version": "7.1.1",
-          "resolved": "https://registry.npm.taobao.org/globby/download/globby-7.1.1.tgz?cache=0&sync_timestamp=1562307970751&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fglobby%2Fdownload%2Fglobby-7.1.1.tgz",
+          "resolved": "https://registry.npmjs.org/globby/-/globby-7.1.1.tgz",
           "integrity": "sha1-+yzP+UAfhgCUXfral0QMypcrhoA=",
           "dev": true,
           "requires": {
@@ -3121,7 +3121,7 @@
         },
         "lru-cache": {
           "version": "4.1.5",
-          "resolved": "https://registry.npm.taobao.org/lru-cache/download/lru-cache-4.1.5.tgz",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.5.tgz",
           "integrity": "sha1-i75Q6oW+1ZvJ4z3KuCNe6bz0Q80=",
           "dev": true,
           "requires": {
@@ -3131,7 +3131,7 @@
         },
         "make-dir": {
           "version": "1.3.0",
-          "resolved": "https://registry.npm.taobao.org/make-dir/download/make-dir-1.3.0.tgz",
+          "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-1.3.0.tgz",
           "integrity": "sha1-ecEDO4BRW9bSTsmTPoYMp17ifww=",
           "dev": true,
           "requires": {
@@ -3140,7 +3140,7 @@
         },
         "mississippi": {
           "version": "2.0.0",
-          "resolved": "https://registry.npm.taobao.org/mississippi/download/mississippi-2.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/mississippi/-/mississippi-2.0.0.tgz",
           "integrity": "sha1-NEKlCPr8KFAEhv7qmUCWduTuWm8=",
           "dev": true,
           "requires": {
@@ -3158,13 +3158,13 @@
         },
         "pify": {
           "version": "3.0.0",
-          "resolved": "https://registry.npm.taobao.org/pify/download/pify-3.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
           "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
           "dev": true
         },
         "pkg-dir": {
           "version": "2.0.0",
-          "resolved": "https://registry.npm.taobao.org/pkg-dir/download/pkg-dir-2.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-2.0.0.tgz",
           "integrity": "sha1-9tXREJ4Z1j7fQo4L1X4Sd3YVM0s=",
           "dev": true,
           "requires": {
@@ -3173,7 +3173,7 @@
         },
         "pump": {
           "version": "2.0.1",
-          "resolved": "https://registry.npm.taobao.org/pump/download/pump-2.0.1.tgz?cache=0&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fpump%2Fdownload%2Fpump-2.0.1.tgz",
+          "resolved": "https://registry.npmjs.org/pump/-/pump-2.0.1.tgz",
           "integrity": "sha1-Ejma3W5M91Jtlzy8i1zi4pCLOQk=",
           "dev": true,
           "requires": {
@@ -3183,13 +3183,13 @@
         },
         "slash": {
           "version": "1.0.0",
-          "resolved": "https://registry.npm.taobao.org/slash/download/slash-1.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/slash/-/slash-1.0.0.tgz",
           "integrity": "sha1-xB8vbDn8FtHNF61LXYlhFK5HDVU=",
           "dev": true
         },
         "ssri": {
           "version": "5.3.0",
-          "resolved": "https://registry.npm.taobao.org/ssri/download/ssri-5.3.0.tgz",
+          "resolved": "https://registry.npmjs.org/ssri/-/ssri-5.3.0.tgz",
           "integrity": "sha1-ujhyycbTOgcEp9cf8EXl7EiZnQY=",
           "dev": true,
           "requires": {
@@ -3198,7 +3198,7 @@
         },
         "yallist": {
           "version": "2.1.2",
-          "resolved": "https://registry.npm.taobao.org/yallist/download/yallist-2.1.2.tgz",
+          "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
           "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=",
           "dev": true
         }
@@ -3206,18 +3206,18 @@
     },
     "core-js": {
       "version": "2.6.9",
-      "resolved": "https://registry.npm.taobao.org/core-js/download/core-js-2.6.9.tgz?cache=0&sync_timestamp=1565301977309&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fcore-js%2Fdownload%2Fcore-js-2.6.9.tgz",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.9.tgz",
       "integrity": "sha1-a0shRiDINBUuF5Mjcn/Bl0GwhPI="
     },
     "core-util-is": {
       "version": "1.0.2",
-      "resolved": "https://registry.npm.taobao.org/core-util-is/download/core-util-is-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
       "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
       "dev": true
     },
     "cosmiconfig": {
       "version": "5.2.1",
-      "resolved": "https://registry.npm.taobao.org/cosmiconfig/download/cosmiconfig-5.2.1.tgz",
+      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-5.2.1.tgz",
       "integrity": "sha1-BA9yaAnFked6F8CjYmykW08Wixo=",
       "dev": true,
       "requires": {
@@ -3229,7 +3229,7 @@
     },
     "create-ecdh": {
       "version": "4.0.3",
-      "resolved": "https://registry.npm.taobao.org/create-ecdh/download/create-ecdh-4.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/create-ecdh/-/create-ecdh-4.0.3.tgz",
       "integrity": "sha1-yREbbzMEXEaX8UR4f5JUzcd8Rf8=",
       "dev": true,
       "requires": {
@@ -3239,7 +3239,7 @@
     },
     "create-hash": {
       "version": "1.2.0",
-      "resolved": "https://registry.npm.taobao.org/create-hash/download/create-hash-1.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/create-hash/-/create-hash-1.2.0.tgz",
       "integrity": "sha1-iJB4rxGmN1a8+1m9IhmWvjqe8ZY=",
       "dev": true,
       "requires": {
@@ -3252,7 +3252,7 @@
     },
     "create-hmac": {
       "version": "1.1.7",
-      "resolved": "https://registry.npm.taobao.org/create-hmac/download/create-hmac-1.1.7.tgz",
+      "resolved": "https://registry.npmjs.org/create-hmac/-/create-hmac-1.1.7.tgz",
       "integrity": "sha1-aRcMeLOrlXFHsriwRXLkfq0iQ/8=",
       "dev": true,
       "requires": {
@@ -3266,7 +3266,7 @@
     },
     "cross-spawn": {
       "version": "6.0.5",
-      "resolved": "https://registry.npm.taobao.org/cross-spawn/download/cross-spawn-6.0.5.tgz",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
       "integrity": "sha1-Sl7Hxk364iw6FBJNus3uhG2Ay8Q=",
       "dev": true,
       "requires": {
@@ -3279,7 +3279,7 @@
     },
     "crypto-browserify": {
       "version": "3.12.0",
-      "resolved": "https://registry.npm.taobao.org/crypto-browserify/download/crypto-browserify-3.12.0.tgz",
+      "resolved": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-3.12.0.tgz",
       "integrity": "sha1-OWz58xN/A+S45TLFj2mCVOAPgOw=",
       "dev": true,
       "requires": {
@@ -3298,13 +3298,13 @@
     },
     "css-color-names": {
       "version": "0.0.4",
-      "resolved": "https://registry.npm.taobao.org/css-color-names/download/css-color-names-0.0.4.tgz",
+      "resolved": "https://registry.npmjs.org/css-color-names/-/css-color-names-0.0.4.tgz",
       "integrity": "sha1-gIrcLnnPhHOAabZGyyDsJ762KeA=",
       "dev": true
     },
     "css-declaration-sorter": {
       "version": "4.0.1",
-      "resolved": "https://registry.npm.taobao.org/css-declaration-sorter/download/css-declaration-sorter-4.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/css-declaration-sorter/-/css-declaration-sorter-4.0.1.tgz",
       "integrity": "sha1-wZiUD2OnbX42wecQGLABchBUyyI=",
       "dev": true,
       "requires": {
@@ -3314,7 +3314,7 @@
     },
     "css-loader": {
       "version": "1.0.1",
-      "resolved": "https://registry.npm.taobao.org/css-loader/download/css-loader-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/css-loader/-/css-loader-1.0.1.tgz",
       "integrity": "sha1-aIW7UjOzXsR7AGBX2gHMZAtref4=",
       "dev": true,
       "requires": {
@@ -3334,7 +3334,7 @@
       "dependencies": {
         "postcss": {
           "version": "6.0.23",
-          "resolved": "https://registry.npm.taobao.org/postcss/download/postcss-6.0.23.tgz?cache=0&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fpostcss%2Fdownload%2Fpostcss-6.0.23.tgz",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.23.tgz",
           "integrity": "sha1-YcgswyisYOZ3ZF+XkFTrmLwOMyQ=",
           "dev": true,
           "requires": {
@@ -3345,7 +3345,7 @@
         },
         "source-map": {
           "version": "0.6.1",
-          "resolved": "https://registry.npm.taobao.org/source-map/download/source-map-0.6.1.tgz",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
           "integrity": "sha1-dHIq8y6WFOnCh6jQu95IteLxomM=",
           "dev": true
         }
@@ -3353,7 +3353,7 @@
     },
     "css-select": {
       "version": "2.0.2",
-      "resolved": "https://registry.npm.taobao.org/css-select/download/css-select-2.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/css-select/-/css-select-2.0.2.tgz",
       "integrity": "sha1-q0OGzsnh9miFVWSxfDcztDsqXt4=",
       "dev": true,
       "requires": {
@@ -3365,13 +3365,13 @@
     },
     "css-select-base-adapter": {
       "version": "0.1.1",
-      "resolved": "https://registry.npm.taobao.org/css-select-base-adapter/download/css-select-base-adapter-0.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/css-select-base-adapter/-/css-select-base-adapter-0.1.1.tgz",
       "integrity": "sha1-Oy/0lyzDYquIVhUHqVQIoUMhNdc=",
       "dev": true
     },
     "css-selector-tokenizer": {
       "version": "0.7.1",
-      "resolved": "https://registry.npm.taobao.org/css-selector-tokenizer/download/css-selector-tokenizer-0.7.1.tgz",
+      "resolved": "https://registry.npmjs.org/css-selector-tokenizer/-/css-selector-tokenizer-0.7.1.tgz",
       "integrity": "sha1-oXcnGovKUBkXL0+JH8bu2cv2jV0=",
       "dev": true,
       "requires": {
@@ -3382,19 +3382,19 @@
       "dependencies": {
         "cssesc": {
           "version": "0.1.0",
-          "resolved": "https://registry.npm.taobao.org/cssesc/download/cssesc-0.1.0.tgz",
+          "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-0.1.0.tgz",
           "integrity": "sha1-yBSQPkViM3GgR3tAEJqq++6t27Q=",
           "dev": true
         },
         "jsesc": {
           "version": "0.5.0",
-          "resolved": "https://registry.npm.taobao.org/jsesc/download/jsesc-0.5.0.tgz",
+          "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz",
           "integrity": "sha1-597mbjXW/Bb3EP6R1c9p9w8IkR0=",
           "dev": true
         },
         "regexpu-core": {
           "version": "1.0.0",
-          "resolved": "https://registry.npm.taobao.org/regexpu-core/download/regexpu-core-1.0.0.tgz?cache=0&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fregexpu-core%2Fdownload%2Fregexpu-core-1.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-1.0.0.tgz",
           "integrity": "sha1-hqdj9Y7k18L2sQLkdkBQ3n7ZDGs=",
           "dev": true,
           "requires": {
@@ -3405,13 +3405,13 @@
         },
         "regjsgen": {
           "version": "0.2.0",
-          "resolved": "https://registry.npm.taobao.org/regjsgen/download/regjsgen-0.2.0.tgz",
+          "resolved": "https://registry.npmjs.org/regjsgen/-/regjsgen-0.2.0.tgz",
           "integrity": "sha1-bAFq3qxVT3WCP+N6wFuS1aTtsfc=",
           "dev": true
         },
         "regjsparser": {
           "version": "0.1.5",
-          "resolved": "https://registry.npm.taobao.org/regjsparser/download/regjsparser-0.1.5.tgz",
+          "resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.1.5.tgz",
           "integrity": "sha1-fuj4Tcb6eS0/0K4ijSS9lJ6tIFw=",
           "dev": true,
           "requires": {
@@ -3422,7 +3422,7 @@
     },
     "css-tree": {
       "version": "1.0.0-alpha.33",
-      "resolved": "https://registry.npm.taobao.org/css-tree/download/css-tree-1.0.0-alpha.33.tgz",
+      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-1.0.0-alpha.33.tgz",
       "integrity": "sha1-lw4g5akfejeN3Q/FjQtsjU876T4=",
       "dev": true,
       "requires": {
@@ -3432,25 +3432,25 @@
     },
     "css-unit-converter": {
       "version": "1.1.1",
-      "resolved": "https://registry.npm.taobao.org/css-unit-converter/download/css-unit-converter-1.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/css-unit-converter/-/css-unit-converter-1.1.1.tgz",
       "integrity": "sha1-2bkoGtz9jO2TW9urqDeGiX9k6ZY=",
       "dev": true
     },
     "css-what": {
       "version": "2.1.3",
-      "resolved": "https://registry.npm.taobao.org/css-what/download/css-what-2.1.3.tgz",
+      "resolved": "https://registry.npmjs.org/css-what/-/css-what-2.1.3.tgz",
       "integrity": "sha1-ptdgRXM2X+dGhsPzEcVlE9iChfI=",
       "dev": true
     },
     "cssesc": {
       "version": "2.0.0",
-      "resolved": "https://registry.npm.taobao.org/cssesc/download/cssesc-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-2.0.0.tgz",
       "integrity": "sha1-OxO9G7HLNuG8taTc0n9UxdyzVwM=",
       "dev": true
     },
     "cssnano": {
       "version": "4.1.10",
-      "resolved": "https://registry.npm.taobao.org/cssnano/download/cssnano-4.1.10.tgz",
+      "resolved": "https://registry.npmjs.org/cssnano/-/cssnano-4.1.10.tgz",
       "integrity": "sha1-CsQfCxPRPUZUh+ERt3jULaYxuLI=",
       "dev": true,
       "requires": {
@@ -3462,7 +3462,7 @@
     },
     "cssnano-preset-default": {
       "version": "4.0.7",
-      "resolved": "https://registry.npm.taobao.org/cssnano-preset-default/download/cssnano-preset-default-4.0.7.tgz",
+      "resolved": "https://registry.npmjs.org/cssnano-preset-default/-/cssnano-preset-default-4.0.7.tgz",
       "integrity": "sha1-UexmLM/KD4izltzZZ5zbkxvhf3Y=",
       "dev": true,
       "requires": {
@@ -3500,19 +3500,19 @@
     },
     "cssnano-util-get-arguments": {
       "version": "4.0.0",
-      "resolved": "https://registry.npm.taobao.org/cssnano-util-get-arguments/download/cssnano-util-get-arguments-4.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/cssnano-util-get-arguments/-/cssnano-util-get-arguments-4.0.0.tgz",
       "integrity": "sha1-7ToIKZ8h11dBsg87gfGU7UnMFQ8=",
       "dev": true
     },
     "cssnano-util-get-match": {
       "version": "4.0.0",
-      "resolved": "https://registry.npm.taobao.org/cssnano-util-get-match/download/cssnano-util-get-match-4.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/cssnano-util-get-match/-/cssnano-util-get-match-4.0.0.tgz",
       "integrity": "sha1-wOTKB/U4a7F+xeUiULT1lhNlFW0=",
       "dev": true
     },
     "cssnano-util-raw-cache": {
       "version": "4.0.1",
-      "resolved": "https://registry.npm.taobao.org/cssnano-util-raw-cache/download/cssnano-util-raw-cache-4.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/cssnano-util-raw-cache/-/cssnano-util-raw-cache-4.0.1.tgz",
       "integrity": "sha1-sm1f1fcqEd/np4RvtMZyYPlr8oI=",
       "dev": true,
       "requires": {
@@ -3521,13 +3521,13 @@
     },
     "cssnano-util-same-parent": {
       "version": "4.0.1",
-      "resolved": "https://registry.npm.taobao.org/cssnano-util-same-parent/download/cssnano-util-same-parent-4.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/cssnano-util-same-parent/-/cssnano-util-same-parent-4.0.1.tgz",
       "integrity": "sha1-V0CC+yhZ0ttDOFWDXZqEVuoYu/M=",
       "dev": true
     },
     "csso": {
       "version": "3.5.1",
-      "resolved": "https://registry.npm.taobao.org/csso/download/csso-3.5.1.tgz",
+      "resolved": "https://registry.npmjs.org/csso/-/csso-3.5.1.tgz",
       "integrity": "sha1-e564vmFiiXPBsmHhadLwJACOdYs=",
       "dev": true,
       "requires": {
@@ -3536,7 +3536,7 @@
       "dependencies": {
         "css-tree": {
           "version": "1.0.0-alpha.29",
-          "resolved": "https://registry.npm.taobao.org/css-tree/download/css-tree-1.0.0-alpha.29.tgz",
+          "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-1.0.0-alpha.29.tgz",
           "integrity": "sha1-P6nU7zFCy9HDAedmTB81K9gvWjk=",
           "dev": true,
           "requires": {
@@ -3546,7 +3546,7 @@
         },
         "mdn-data": {
           "version": "1.1.4",
-          "resolved": "https://registry.npm.taobao.org/mdn-data/download/mdn-data-1.1.4.tgz",
+          "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-1.1.4.tgz",
           "integrity": "sha1-ULXU/8RXUnZXPE7tuHgIEqhBnwE=",
           "dev": true
         }
@@ -3554,19 +3554,19 @@
     },
     "current-script-polyfill": {
       "version": "1.0.0",
-      "resolved": "https://registry.npm.taobao.org/current-script-polyfill/download/current-script-polyfill-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/current-script-polyfill/-/current-script-polyfill-1.0.0.tgz",
       "integrity": "sha1-8xz35PPiGLBybnOMqSoC00iO9hU=",
       "dev": true
     },
     "cyclist": {
       "version": "0.2.2",
-      "resolved": "https://registry.npm.taobao.org/cyclist/download/cyclist-0.2.2.tgz",
+      "resolved": "https://registry.npmjs.org/cyclist/-/cyclist-0.2.2.tgz",
       "integrity": "sha1-GzN5LhHpFKL9bW7WRHRkRE5fpkA=",
       "dev": true
     },
     "dashdash": {
       "version": "1.14.1",
-      "resolved": "https://registry.npm.taobao.org/dashdash/download/dashdash-1.14.1.tgz",
+      "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
       "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
       "dev": true,
       "requires": {
@@ -3575,19 +3575,19 @@
     },
     "date-now": {
       "version": "0.1.4",
-      "resolved": "https://registry.npm.taobao.org/date-now/download/date-now-0.1.4.tgz",
+      "resolved": "https://registry.npmjs.org/date-now/-/date-now-0.1.4.tgz",
       "integrity": "sha1-6vQ5/U1ISK105cx9vvIAZyueNFs=",
       "dev": true
     },
     "de-indent": {
       "version": "1.0.2",
-      "resolved": "https://registry.npm.taobao.org/de-indent/download/de-indent-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/de-indent/-/de-indent-1.0.2.tgz",
       "integrity": "sha1-sgOOhG3DO6pXlhKNCAS0VbjB4h0=",
       "dev": true
     },
     "debug": {
       "version": "4.1.1",
-      "resolved": "https://registry.npm.taobao.org/debug/download/debug-4.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
       "integrity": "sha1-O3ImAlUQnGtYnO4FDx1RYTlmR5E=",
       "dev": true,
       "requires": {
@@ -3596,31 +3596,31 @@
     },
     "decamelize": {
       "version": "1.2.0",
-      "resolved": "https://registry.npm.taobao.org/decamelize/download/decamelize-1.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
       "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
       "dev": true
     },
     "decode-uri-component": {
       "version": "0.2.0",
-      "resolved": "https://registry.npm.taobao.org/decode-uri-component/download/decode-uri-component-0.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
       "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU=",
       "dev": true
     },
     "deep-equal": {
       "version": "1.0.1",
-      "resolved": "https://registry.npm.taobao.org/deep-equal/download/deep-equal-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.0.1.tgz",
       "integrity": "sha1-9dJgKStmDghO/0zbyfCK0yR0SLU=",
       "dev": true
     },
     "deep-is": {
       "version": "0.1.3",
-      "resolved": "https://registry.npm.taobao.org/deep-is/download/deep-is-0.1.3.tgz",
+      "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
       "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=",
       "dev": true
     },
     "default-gateway": {
       "version": "5.0.2",
-      "resolved": "https://registry.npm.taobao.org/default-gateway/download/default-gateway-5.0.2.tgz?cache=0&sync_timestamp=1560569240081&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fdefault-gateway%2Fdownload%2Fdefault-gateway-5.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/default-gateway/-/default-gateway-5.0.2.tgz",
       "integrity": "sha1-0tihPW/uQG2TZdGeya3MuKYLgrM=",
       "dev": true,
       "requires": {
@@ -3630,7 +3630,7 @@
     },
     "defaults": {
       "version": "1.0.3",
-      "resolved": "https://registry.npm.taobao.org/defaults/download/defaults-1.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/defaults/-/defaults-1.0.3.tgz",
       "integrity": "sha1-xlYFHpgX2f8I7YgUd/P+QBnz730=",
       "dev": true,
       "requires": {
@@ -3639,7 +3639,7 @@
     },
     "define-properties": {
       "version": "1.1.3",
-      "resolved": "https://registry.npm.taobao.org/define-properties/download/define-properties-1.1.3.tgz",
+      "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.3.tgz",
       "integrity": "sha1-z4jabL7ib+bbcJT2HYcMvYTO6fE=",
       "dev": true,
       "requires": {
@@ -3648,7 +3648,7 @@
     },
     "define-property": {
       "version": "2.0.2",
-      "resolved": "https://registry.npm.taobao.org/define-property/download/define-property-2.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/define-property/-/define-property-2.0.2.tgz",
       "integrity": "sha1-1Flono1lS6d+AqgX+HENcCyxbp0=",
       "dev": true,
       "requires": {
@@ -3658,7 +3658,7 @@
       "dependencies": {
         "is-accessor-descriptor": {
           "version": "1.0.0",
-          "resolved": "https://registry.npm.taobao.org/is-accessor-descriptor/download/is-accessor-descriptor-1.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
           "integrity": "sha1-FpwvbT3x+ZJhgHI2XJsOofaHhlY=",
           "dev": true,
           "requires": {
@@ -3667,7 +3667,7 @@
         },
         "is-data-descriptor": {
           "version": "1.0.0",
-          "resolved": "https://registry.npm.taobao.org/is-data-descriptor/download/is-data-descriptor-1.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
           "integrity": "sha1-2Eh2Mh0Oet0DmQQGq7u9NrqSaMc=",
           "dev": true,
           "requires": {
@@ -3676,7 +3676,7 @@
         },
         "is-descriptor": {
           "version": "1.0.2",
-          "resolved": "https://registry.npm.taobao.org/is-descriptor/download/is-descriptor-1.0.2.tgz",
+          "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
           "integrity": "sha1-OxWXRqZmBLBPjIFSS6NlxfFNhuw=",
           "dev": true,
           "requires": {
@@ -3689,7 +3689,7 @@
     },
     "del": {
       "version": "4.1.1",
-      "resolved": "https://registry.npm.taobao.org/del/download/del-4.1.1.tgz?cache=0&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fdel%2Fdownload%2Fdel-4.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/del/-/del-4.1.1.tgz",
       "integrity": "sha1-no8RciLqRKMf86FWwEm5kFKp8LQ=",
       "dev": true,
       "requires": {
@@ -3704,7 +3704,7 @@
       "dependencies": {
         "globby": {
           "version": "6.1.0",
-          "resolved": "https://registry.npm.taobao.org/globby/download/globby-6.1.0.tgz?cache=0&sync_timestamp=1562307970751&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fglobby%2Fdownload%2Fglobby-6.1.0.tgz",
+          "resolved": "https://registry.npmjs.org/globby/-/globby-6.1.0.tgz",
           "integrity": "sha1-9abXDoOV4hyFj7BInWTfAkJNUGw=",
           "dev": true,
           "requires": {
@@ -3717,7 +3717,7 @@
           "dependencies": {
             "pify": {
               "version": "2.3.0",
-              "resolved": "https://registry.npm.taobao.org/pify/download/pify-2.3.0.tgz",
+              "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
               "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
               "dev": true
             }
@@ -3727,19 +3727,19 @@
     },
     "delayed-stream": {
       "version": "1.0.0",
-      "resolved": "https://registry.npm.taobao.org/delayed-stream/download/delayed-stream-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
       "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
       "dev": true
     },
     "depd": {
       "version": "1.1.2",
-      "resolved": "https://registry.npm.taobao.org/depd/download/depd-1.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
       "integrity": "sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak=",
       "dev": true
     },
     "des.js": {
       "version": "1.0.0",
-      "resolved": "https://registry.npm.taobao.org/des.js/download/des.js-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/des.js/-/des.js-1.0.0.tgz",
       "integrity": "sha1-wHTS4qpqipoH29YfmhXCzYPsjsw=",
       "dev": true,
       "requires": {
@@ -3749,19 +3749,19 @@
     },
     "destroy": {
       "version": "1.0.4",
-      "resolved": "https://registry.npm.taobao.org/destroy/download/destroy-1.0.4.tgz",
+      "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz",
       "integrity": "sha1-l4hXRCxEdJ5CBmE+N5RiBYJqvYA=",
       "dev": true
     },
     "detect-node": {
       "version": "2.0.4",
-      "resolved": "https://registry.npm.taobao.org/detect-node/download/detect-node-2.0.4.tgz",
+      "resolved": "https://registry.npmjs.org/detect-node/-/detect-node-2.0.4.tgz",
       "integrity": "sha1-AU7o+PZpxcWAI9pkuBecCDooxGw=",
       "dev": true
     },
     "diffie-hellman": {
       "version": "5.0.3",
-      "resolved": "https://registry.npm.taobao.org/diffie-hellman/download/diffie-hellman-5.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/diffie-hellman/-/diffie-hellman-5.0.3.tgz",
       "integrity": "sha1-QOjumPVaIUlgcUaSHGPhrl89KHU=",
       "dev": true,
       "requires": {
@@ -3772,7 +3772,7 @@
     },
     "dir-glob": {
       "version": "2.2.2",
-      "resolved": "https://registry.npm.taobao.org/dir-glob/download/dir-glob-2.2.2.tgz?cache=0&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fdir-glob%2Fdownload%2Fdir-glob-2.2.2.tgz",
+      "resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-2.2.2.tgz",
       "integrity": "sha1-+gnwaUFTyJGLGLoN6vrpR2n8UMQ=",
       "dev": true,
       "requires": {
@@ -3781,13 +3781,13 @@
     },
     "dns-equal": {
       "version": "1.0.0",
-      "resolved": "https://registry.npm.taobao.org/dns-equal/download/dns-equal-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/dns-equal/-/dns-equal-1.0.0.tgz",
       "integrity": "sha1-s55/HabrCnW6nBcySzR1PEfgZU0=",
       "dev": true
     },
     "dns-packet": {
       "version": "1.3.1",
-      "resolved": "https://registry.npm.taobao.org/dns-packet/download/dns-packet-1.3.1.tgz",
+      "resolved": "https://registry.npmjs.org/dns-packet/-/dns-packet-1.3.1.tgz",
       "integrity": "sha1-EqpCaYEHW+UAuRDu3NC0fdfe2lo=",
       "dev": true,
       "requires": {
@@ -3797,7 +3797,7 @@
     },
     "dns-txt": {
       "version": "2.0.2",
-      "resolved": "https://registry.npm.taobao.org/dns-txt/download/dns-txt-2.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/dns-txt/-/dns-txt-2.0.2.tgz",
       "integrity": "sha1-uR2Ab10nGI5Ks+fRB9iBocxGQrY=",
       "dev": true,
       "requires": {
@@ -3806,7 +3806,7 @@
     },
     "doctrine": {
       "version": "2.1.0",
-      "resolved": "https://registry.npm.taobao.org/doctrine/download/doctrine-2.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.1.0.tgz",
       "integrity": "sha1-XNAfwQFiG0LEzX9dGmYkNxbT850=",
       "dev": true,
       "optional": true,
@@ -3816,7 +3816,7 @@
     },
     "dom-converter": {
       "version": "0.2.0",
-      "resolved": "https://registry.npm.taobao.org/dom-converter/download/dom-converter-0.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/dom-converter/-/dom-converter-0.2.0.tgz",
       "integrity": "sha1-ZyGp2u4uKTaClVtq/kFncWJ7t2g=",
       "dev": true,
       "requires": {
@@ -3825,7 +3825,7 @@
     },
     "dom-serializer": {
       "version": "0.2.1",
-      "resolved": "https://registry.npm.taobao.org/dom-serializer/download/dom-serializer-0.2.1.tgz?cache=0&sync_timestamp=1564710970695&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fdom-serializer%2Fdownload%2Fdom-serializer-0.2.1.tgz",
+      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-0.2.1.tgz",
       "integrity": "sha1-E2UMhQ2v/qNdi2JqTPxNOhdkP9s=",
       "dev": true,
       "requires": {
@@ -3835,7 +3835,7 @@
       "dependencies": {
         "domelementtype": {
           "version": "2.0.1",
-          "resolved": "https://registry.npm.taobao.org/domelementtype/download/domelementtype-2.0.1.tgz",
+          "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.0.1.tgz",
           "integrity": "sha1-H4vf6R9aeAYydOgDtL3O326U+U0=",
           "dev": true
         }
@@ -3843,19 +3843,19 @@
     },
     "domain-browser": {
       "version": "1.2.0",
-      "resolved": "https://registry.npm.taobao.org/domain-browser/download/domain-browser-1.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/domain-browser/-/domain-browser-1.2.0.tgz",
       "integrity": "sha1-PTH1AZGmdJ3RN1p/Ui6CPULlTto=",
       "dev": true
     },
     "domelementtype": {
       "version": "1.3.1",
-      "resolved": "https://registry.npm.taobao.org/domelementtype/download/domelementtype-1.3.1.tgz",
+      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.3.1.tgz",
       "integrity": "sha1-0EjESzew0Qp/Kj1f7j9DM9eQSB8=",
       "dev": true
     },
     "domhandler": {
       "version": "2.4.2",
-      "resolved": "https://registry.npm.taobao.org/domhandler/download/domhandler-2.4.2.tgz?cache=0&sync_timestamp=1564708887907&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fdomhandler%2Fdownload%2Fdomhandler-2.4.2.tgz",
+      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-2.4.2.tgz",
       "integrity": "sha1-iAUJfpM9ZehVRvcm1g9euItE+AM=",
       "dev": true,
       "requires": {
@@ -3864,7 +3864,7 @@
     },
     "domutils": {
       "version": "1.7.0",
-      "resolved": "https://registry.npm.taobao.org/domutils/download/domutils-1.7.0.tgz",
+      "resolved": "https://registry.npmjs.org/domutils/-/domutils-1.7.0.tgz",
       "integrity": "sha1-Vuo0HoNOBuZ0ivehyyXaZ+qfjCo=",
       "dev": true,
       "requires": {
@@ -3874,7 +3874,7 @@
     },
     "dot-prop": {
       "version": "4.2.0",
-      "resolved": "https://registry.npm.taobao.org/dot-prop/download/dot-prop-4.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-4.2.0.tgz",
       "integrity": "sha1-HxngwuGqDjJ5fEl5nyg3rGr2nFc=",
       "dev": true,
       "requires": {
@@ -3883,25 +3883,25 @@
     },
     "dotenv": {
       "version": "7.0.0",
-      "resolved": "https://registry.npm.taobao.org/dotenv/download/dotenv-7.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-7.0.0.tgz",
       "integrity": "sha1-or481Sc2ZzIG6KhftSEO6ilijnw=",
       "dev": true
     },
     "dotenv-expand": {
       "version": "5.1.0",
-      "resolved": "https://registry.npm.taobao.org/dotenv-expand/download/dotenv-expand-5.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/dotenv-expand/-/dotenv-expand-5.1.0.tgz",
       "integrity": "sha1-P7rwIL/XlIhAcuomsel5HUWmKfA=",
       "dev": true
     },
     "duplexer": {
       "version": "0.1.1",
-      "resolved": "https://registry.npm.taobao.org/duplexer/download/duplexer-0.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.1.tgz",
       "integrity": "sha1-rOb/gIwc5mtX0ev5eXessCM0z8E=",
       "dev": true
     },
     "duplexify": {
       "version": "3.7.1",
-      "resolved": "https://registry.npm.taobao.org/duplexify/download/duplexify-3.7.1.tgz",
+      "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-3.7.1.tgz",
       "integrity": "sha1-Kk31MX9sz9kfhtb9JdjYoQO4gwk=",
       "dev": true,
       "requires": {
@@ -3913,13 +3913,13 @@
     },
     "easy-stack": {
       "version": "1.0.0",
-      "resolved": "https://registry.npm.taobao.org/easy-stack/download/easy-stack-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/easy-stack/-/easy-stack-1.0.0.tgz",
       "integrity": "sha1-EskbMIWjfwuqM26UhurEv5Tj54g=",
       "dev": true
     },
     "ecc-jsbn": {
       "version": "0.1.2",
-      "resolved": "https://registry.npm.taobao.org/ecc-jsbn/download/ecc-jsbn-0.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
       "integrity": "sha1-OoOpBOVDUyh4dMVkt1SThoSamMk=",
       "dev": true,
       "requires": {
@@ -3929,25 +3929,25 @@
     },
     "ee-first": {
       "version": "1.1.1",
-      "resolved": "https://registry.npm.taobao.org/ee-first/download/ee-first-1.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
       "integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0=",
       "dev": true
     },
     "ejs": {
       "version": "2.6.2",
-      "resolved": "https://registry.npm.taobao.org/ejs/download/ejs-2.6.2.tgz",
+      "resolved": "https://registry.npmjs.org/ejs/-/ejs-2.6.2.tgz",
       "integrity": "sha1-OjLGPRzRbREmbNRwOxT+xOdKtPY=",
       "dev": true
     },
     "electron-to-chromium": {
       "version": "1.3.222",
-      "resolved": "https://registry.npm.taobao.org/electron-to-chromium/download/electron-to-chromium-1.3.222.tgz",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.222.tgz",
       "integrity": "sha1-Kg44kDsiVNeY3Yg3UHtbxCx+OTQ=",
       "dev": true
     },
     "elliptic": {
       "version": "6.5.0",
-      "resolved": "https://registry.npm.taobao.org/elliptic/download/elliptic-6.5.0.tgz",
+      "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.0.tgz",
       "integrity": "sha1-K47UyJG33jIA4UQSpbgkjHr1Bco=",
       "dev": true,
       "requires": {
@@ -3962,25 +3962,25 @@
     },
     "emoji-regex": {
       "version": "7.0.3",
-      "resolved": "https://registry.npm.taobao.org/emoji-regex/download/emoji-regex-7.0.3.tgz?cache=0&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Femoji-regex%2Fdownload%2Femoji-regex-7.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
       "integrity": "sha1-kzoEBShgyF6DwSJHnEdIqOTHIVY=",
       "dev": true
     },
     "emojis-list": {
       "version": "2.1.0",
-      "resolved": "https://registry.npm.taobao.org/emojis-list/download/emojis-list-2.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/emojis-list/-/emojis-list-2.1.0.tgz",
       "integrity": "sha1-TapNnbAPmBmIDHn6RXrlsJof04k=",
       "dev": true
     },
     "encodeurl": {
       "version": "1.0.2",
-      "resolved": "https://registry.npm.taobao.org/encodeurl/download/encodeurl-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
       "integrity": "sha1-rT/0yG7C0CkyL1oCw6mmBslbP1k=",
       "dev": true
     },
     "end-of-stream": {
       "version": "1.4.1",
-      "resolved": "https://registry.npm.taobao.org/end-of-stream/download/end-of-stream-1.4.1.tgz",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.1.tgz",
       "integrity": "sha1-7SljTRm6ukY7bOa4CjchPqtx7EM=",
       "dev": true,
       "requires": {
@@ -3989,7 +3989,7 @@
     },
     "enhanced-resolve": {
       "version": "4.1.0",
-      "resolved": "https://registry.npm.taobao.org/enhanced-resolve/download/enhanced-resolve-4.1.0.tgz?cache=0&sync_timestamp=1562718443401&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fenhanced-resolve%2Fdownload%2Fenhanced-resolve-4.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-4.1.0.tgz",
       "integrity": "sha1-Qcfgv9/nSsH/4eV61qXGyfN0Kn8=",
       "dev": true,
       "requires": {
@@ -4000,13 +4000,13 @@
     },
     "entities": {
       "version": "2.0.0",
-      "resolved": "https://registry.npm.taobao.org/entities/download/entities-2.0.0.tgz?cache=0&sync_timestamp=1563403318326&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fentities%2Fdownload%2Fentities-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-2.0.0.tgz",
       "integrity": "sha1-aNYITKsbB5dnVA2A5Wo5tCPkq/Q=",
       "dev": true
     },
     "errno": {
       "version": "0.1.7",
-      "resolved": "https://registry.npm.taobao.org/errno/download/errno-0.1.7.tgz",
+      "resolved": "https://registry.npmjs.org/errno/-/errno-0.1.7.tgz",
       "integrity": "sha1-RoTXF3mtOa8Xfj8AeZb3xnyFJhg=",
       "dev": true,
       "requires": {
@@ -4015,7 +4015,7 @@
     },
     "error-ex": {
       "version": "1.3.2",
-      "resolved": "https://registry.npm.taobao.org/error-ex/download/error-ex-1.3.2.tgz",
+      "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.2.tgz",
       "integrity": "sha1-tKxAZIEH/c3PriQvQovqihTU8b8=",
       "dev": true,
       "requires": {
@@ -4024,7 +4024,7 @@
     },
     "error-stack-parser": {
       "version": "2.0.2",
-      "resolved": "https://registry.npm.taobao.org/error-stack-parser/download/error-stack-parser-2.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/error-stack-parser/-/error-stack-parser-2.0.2.tgz",
       "integrity": "sha1-Sujbqiv5CotFBwe5FJ3KvKE1Ug0=",
       "dev": true,
       "requires": {
@@ -4033,7 +4033,7 @@
     },
     "es-abstract": {
       "version": "1.13.0",
-      "resolved": "https://registry.npm.taobao.org/es-abstract/download/es-abstract-1.13.0.tgz",
+      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.13.0.tgz",
       "integrity": "sha1-rIYUX91QmdjdSVWMy6Lq+biOJOk=",
       "dev": true,
       "requires": {
@@ -4047,7 +4047,7 @@
     },
     "es-to-primitive": {
       "version": "1.2.0",
-      "resolved": "https://registry.npm.taobao.org/es-to-primitive/download/es-to-primitive-1.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.0.tgz",
       "integrity": "sha1-7fckeAM0VujdqO8J4ArZZQcH83c=",
       "dev": true,
       "requires": {
@@ -4058,19 +4058,19 @@
     },
     "escape-html": {
       "version": "1.0.3",
-      "resolved": "https://registry.npm.taobao.org/escape-html/download/escape-html-1.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
       "integrity": "sha1-Aljq5NPQwJdN4cFpGI7wBR0dGYg=",
       "dev": true
     },
     "escape-string-regexp": {
       "version": "1.0.5",
-      "resolved": "https://registry.npm.taobao.org/escape-string-regexp/download/escape-string-regexp-1.0.5.tgz",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
       "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
       "dev": true
     },
     "eslint": {
       "version": "5.16.0",
-      "resolved": "https://registry.npm.taobao.org/eslint/download/eslint-5.16.0.tgz",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-5.16.0.tgz",
       "integrity": "sha1-oeOsGq5KP72Clvz496tzFMu2q+o=",
       "dev": true,
       "requires": {
@@ -4114,25 +4114,25 @@
       "dependencies": {
         "acorn": {
           "version": "6.2.1",
-          "resolved": "https://registry.npm.taobao.org/acorn/download/acorn-6.2.1.tgz",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.2.1.tgz",
           "integrity": "sha1-PthCLW3sCeYSHMeoQ8qGozCoa1E=",
           "dev": true
         },
         "acorn-jsx": {
           "version": "5.0.1",
-          "resolved": "https://registry.npm.taobao.org/acorn-jsx/download/acorn-jsx-5.0.1.tgz",
+          "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.0.1.tgz",
           "integrity": "sha1-MqBk/ZJUKSFqCbFBECv90YX65A4=",
           "dev": true
         },
         "chardet": {
           "version": "0.7.0",
-          "resolved": "https://registry.npm.taobao.org/chardet/download/chardet-0.7.0.tgz",
+          "resolved": "https://registry.npmjs.org/chardet/-/chardet-0.7.0.tgz",
           "integrity": "sha1-kAlISfCTfy7twkJdDSip5fDLrZ4=",
           "dev": true
         },
         "doctrine": {
           "version": "3.0.0",
-          "resolved": "https://registry.npm.taobao.org/doctrine/download/doctrine-3.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-3.0.0.tgz",
           "integrity": "sha1-rd6+rXKmV023g2OdyHoSF3OXOWE=",
           "dev": true,
           "requires": {
@@ -4141,7 +4141,7 @@
         },
         "espree": {
           "version": "5.0.1",
-          "resolved": "https://registry.npm.taobao.org/espree/download/espree-5.0.1.tgz",
+          "resolved": "https://registry.npmjs.org/espree/-/espree-5.0.1.tgz",
           "integrity": "sha1-XWUm+k/H8HiKXPdbFfMDI+L4H3o=",
           "dev": true,
           "requires": {
@@ -4152,7 +4152,7 @@
         },
         "external-editor": {
           "version": "3.1.0",
-          "resolved": "https://registry.npm.taobao.org/external-editor/download/external-editor-3.1.0.tgz?cache=0&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fexternal-editor%2Fdownload%2Fexternal-editor-3.1.0.tgz",
+          "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-3.1.0.tgz",
           "integrity": "sha1-ywP3QL764D6k0oPK7SdBqD8zVJU=",
           "dev": true,
           "requires": {
@@ -4163,7 +4163,7 @@
         },
         "file-entry-cache": {
           "version": "5.0.1",
-          "resolved": "https://registry.npm.taobao.org/file-entry-cache/download/file-entry-cache-5.0.1.tgz",
+          "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-5.0.1.tgz",
           "integrity": "sha1-yg9u+m3T1WEzP7FFFQZcL6/fQ5w=",
           "dev": true,
           "requires": {
@@ -4172,7 +4172,7 @@
         },
         "flat-cache": {
           "version": "2.0.1",
-          "resolved": "https://registry.npm.taobao.org/flat-cache/download/flat-cache-2.0.1.tgz",
+          "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-2.0.1.tgz",
           "integrity": "sha1-XSltbwS9pEpGMKMBQTvbwuwIXsA=",
           "dev": true,
           "requires": {
@@ -4183,13 +4183,13 @@
         },
         "ignore": {
           "version": "4.0.6",
-          "resolved": "https://registry.npm.taobao.org/ignore/download/ignore-4.0.6.tgz",
+          "resolved": "https://registry.npmjs.org/ignore/-/ignore-4.0.6.tgz",
           "integrity": "sha1-dQ49tYYgh7RzfrrIIH/9HvJ7Jfw=",
           "dev": true
         },
         "import-fresh": {
           "version": "3.1.0",
-          "resolved": "https://registry.npm.taobao.org/import-fresh/download/import-fresh-3.1.0.tgz",
+          "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.1.0.tgz",
           "integrity": "sha1-bTP6Hc7235MPrgA0RvM0Fa+QURg=",
           "dev": true,
           "requires": {
@@ -4199,7 +4199,7 @@
         },
         "inquirer": {
           "version": "6.5.0",
-          "resolved": "https://registry.npm.taobao.org/inquirer/download/inquirer-6.5.0.tgz",
+          "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-6.5.0.tgz",
           "integrity": "sha1-IwMxfvyaTqfsLi32+GVptzSsz0I=",
           "dev": true,
           "requires": {
@@ -4220,7 +4220,7 @@
           "dependencies": {
             "strip-ansi": {
               "version": "5.2.0",
-              "resolved": "https://registry.npm.taobao.org/strip-ansi/download/strip-ansi-5.2.0.tgz",
+              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
               "integrity": "sha1-jJpTb+tq/JYr36WxBKUJHBrZwK4=",
               "dev": true,
               "requires": {
@@ -4231,19 +4231,19 @@
         },
         "regexpp": {
           "version": "2.0.1",
-          "resolved": "https://registry.npm.taobao.org/regexpp/download/regexpp-2.0.1.tgz",
+          "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-2.0.1.tgz",
           "integrity": "sha1-jRnTHPYySCtYkEn4KB+T28uk0H8=",
           "dev": true
         },
         "resolve-from": {
           "version": "4.0.0",
-          "resolved": "https://registry.npm.taobao.org/resolve-from/download/resolve-from-4.0.0.tgz?cache=0&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fresolve-from%2Fdownload%2Fresolve-from-4.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
           "integrity": "sha1-SrzYUq0y3Xuqv+m0DgCjbbXzkuY=",
           "dev": true
         },
         "slice-ansi": {
           "version": "2.1.0",
-          "resolved": "https://registry.npm.taobao.org/slice-ansi/download/slice-ansi-2.1.0.tgz",
+          "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-2.1.0.tgz",
           "integrity": "sha1-ys12k0YaY3pXiNkqfdT7oGjoFjY=",
           "dev": true,
           "requires": {
@@ -4254,7 +4254,7 @@
         },
         "strip-ansi": {
           "version": "4.0.0",
-          "resolved": "https://registry.npm.taobao.org/strip-ansi/download/strip-ansi-4.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
           "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
           "dev": true,
           "requires": {
@@ -4263,7 +4263,7 @@
           "dependencies": {
             "ansi-regex": {
               "version": "3.0.0",
-              "resolved": "https://registry.npm.taobao.org/ansi-regex/download/ansi-regex-3.0.0.tgz",
+              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
               "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
               "dev": true
             }
@@ -4271,7 +4271,7 @@
         },
         "table": {
           "version": "5.4.5",
-          "resolved": "https://registry.npm.taobao.org/table/download/table-5.4.5.tgz?cache=0&sync_timestamp=1564593837345&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Ftable%2Fdownload%2Ftable-5.4.5.tgz",
+          "resolved": "https://registry.npmjs.org/table/-/table-5.4.5.tgz",
           "integrity": "sha1-yPTqLY/uCMACf6wnsOwKT+Ad+kI=",
           "dev": true,
           "requires": {
@@ -4283,7 +4283,7 @@
           "dependencies": {
             "string-width": {
               "version": "3.1.0",
-              "resolved": "https://registry.npm.taobao.org/string-width/download/string-width-3.1.0.tgz",
+              "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
               "integrity": "sha1-InZ74htirxCBV0MG9prFG2IgOWE=",
               "dev": true,
               "requires": {
@@ -4294,7 +4294,7 @@
             },
             "strip-ansi": {
               "version": "5.2.0",
-              "resolved": "https://registry.npm.taobao.org/strip-ansi/download/strip-ansi-5.2.0.tgz",
+              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
               "integrity": "sha1-jJpTb+tq/JYr36WxBKUJHBrZwK4=",
               "dev": true,
               "requires": {
@@ -4305,7 +4305,7 @@
         },
         "write": {
           "version": "1.0.3",
-          "resolved": "https://registry.npm.taobao.org/write/download/write-1.0.3.tgz",
+          "resolved": "https://registry.npmjs.org/write/-/write-1.0.3.tgz",
           "integrity": "sha1-CADhRSO5I6OH5BUSPIZWFqrg9cM=",
           "dev": true,
           "requires": {
@@ -4316,7 +4316,7 @@
     },
     "eslint-loader": {
       "version": "2.2.1",
-      "resolved": "https://registry.npm.taobao.org/eslint-loader/download/eslint-loader-2.2.1.tgz",
+      "resolved": "https://registry.npmjs.org/eslint-loader/-/eslint-loader-2.2.1.tgz",
       "integrity": "sha1-KLnBLaVAV68IReKmEScBova/gzc=",
       "dev": true,
       "requires": {
@@ -4329,7 +4329,7 @@
     },
     "eslint-plugin-vue": {
       "version": "5.2.3",
-      "resolved": "https://registry.npm.taobao.org/eslint-plugin-vue/download/eslint-plugin-vue-5.2.3.tgz",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-vue/-/eslint-plugin-vue-5.2.3.tgz",
       "integrity": "sha1-PudZfYI7VHiASy/rqYY7G3QnOWE=",
       "dev": true,
       "requires": {
@@ -4338,19 +4338,19 @@
       "dependencies": {
         "acorn": {
           "version": "6.2.1",
-          "resolved": "https://registry.npm.taobao.org/acorn/download/acorn-6.2.1.tgz",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.2.1.tgz",
           "integrity": "sha1-PthCLW3sCeYSHMeoQ8qGozCoa1E=",
           "dev": true
         },
         "acorn-jsx": {
           "version": "5.0.1",
-          "resolved": "https://registry.npm.taobao.org/acorn-jsx/download/acorn-jsx-5.0.1.tgz",
+          "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.0.1.tgz",
           "integrity": "sha1-MqBk/ZJUKSFqCbFBECv90YX65A4=",
           "dev": true
         },
         "espree": {
           "version": "4.1.0",
-          "resolved": "https://registry.npm.taobao.org/espree/download/espree-4.1.0.tgz",
+          "resolved": "https://registry.npmjs.org/espree/-/espree-4.1.0.tgz",
           "integrity": "sha1-co1UUeD9FWwEOEp62J7VH/VOsl8=",
           "dev": true,
           "requires": {
@@ -4361,7 +4361,7 @@
         },
         "vue-eslint-parser": {
           "version": "5.0.0",
-          "resolved": "https://registry.npm.taobao.org/vue-eslint-parser/download/vue-eslint-parser-5.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/vue-eslint-parser/-/vue-eslint-parser-5.0.0.tgz",
           "integrity": "sha1-APTk2pTsl0uCGib/DtD3p4QCuKE=",
           "dev": true,
           "requires": {
@@ -4377,7 +4377,7 @@
     },
     "eslint-scope": {
       "version": "4.0.3",
-      "resolved": "https://registry.npm.taobao.org/eslint-scope/download/eslint-scope-4.0.3.tgz?cache=0&sync_timestamp=1563679289211&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Feslint-scope%2Fdownload%2Feslint-scope-4.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-4.0.3.tgz",
       "integrity": "sha1-ygODMxD2iJoyZHgaqC5j65z+eEg=",
       "dev": true,
       "requires": {
@@ -4387,7 +4387,7 @@
     },
     "eslint-utils": {
       "version": "1.4.0",
-      "resolved": "https://registry.npm.taobao.org/eslint-utils/download/eslint-utils-1.4.0.tgz",
+      "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-1.4.0.tgz",
       "integrity": "sha1-4sPI26doQl+JfPD55R/i4kFIXUw=",
       "dev": true,
       "requires": {
@@ -4396,13 +4396,13 @@
     },
     "eslint-visitor-keys": {
       "version": "1.0.0",
-      "resolved": "https://registry.npm.taobao.org/eslint-visitor-keys/download/eslint-visitor-keys-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.0.0.tgz",
       "integrity": "sha1-PzGA+y4pEBdxastMnW1bXDSmqB0=",
       "dev": true
     },
     "espree": {
       "version": "3.5.4",
-      "resolved": "https://registry.npm.taobao.org/espree/download/espree-3.5.4.tgz",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-3.5.4.tgz",
       "integrity": "sha1-sPRHGHyKi+2US4FaZgvd9d610ac=",
       "dev": true,
       "optional": true,
@@ -4413,13 +4413,13 @@
     },
     "esprima": {
       "version": "4.0.1",
-      "resolved": "https://registry.npm.taobao.org/esprima/download/esprima-4.0.1.tgz?cache=0&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fesprima%2Fdownload%2Fesprima-4.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
       "integrity": "sha1-E7BM2z5sXRnfkatph6hpVhmwqnE=",
       "dev": true
     },
     "esquery": {
       "version": "1.0.1",
-      "resolved": "https://registry.npm.taobao.org/esquery/download/esquery-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.0.1.tgz",
       "integrity": "sha1-QGxRZYsfWZGl+bYrHcJbAOPlxwg=",
       "dev": true,
       "requires": {
@@ -4428,7 +4428,7 @@
     },
     "esrecurse": {
       "version": "4.2.1",
-      "resolved": "https://registry.npm.taobao.org/esrecurse/download/esrecurse-4.2.1.tgz",
+      "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.2.1.tgz",
       "integrity": "sha1-AHo7n9vCs7uH5IeeoZyS/b05Qs8=",
       "dev": true,
       "requires": {
@@ -4437,43 +4437,43 @@
     },
     "estraverse": {
       "version": "4.2.0",
-      "resolved": "https://registry.npm.taobao.org/estraverse/download/estraverse-4.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.2.0.tgz",
       "integrity": "sha1-De4/7TH81GlhjOc0IJn8GvoL2xM=",
       "dev": true
     },
     "esutils": {
       "version": "2.0.3",
-      "resolved": "https://registry.npm.taobao.org/esutils/download/esutils-2.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
       "integrity": "sha1-dNLrTeC42hKTcRkQ1Qd1ubcQ72Q=",
       "dev": true
     },
     "etag": {
       "version": "1.8.1",
-      "resolved": "https://registry.npm.taobao.org/etag/download/etag-1.8.1.tgz",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
       "integrity": "sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc=",
       "dev": true
     },
     "event-pubsub": {
       "version": "4.3.0",
-      "resolved": "https://registry.npm.taobao.org/event-pubsub/download/event-pubsub-4.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/event-pubsub/-/event-pubsub-4.3.0.tgz",
       "integrity": "sha1-9o2Ba8KfHsAsU53FjI3UDOcss24=",
       "dev": true
     },
     "eventemitter3": {
       "version": "3.1.2",
-      "resolved": "https://registry.npm.taobao.org/eventemitter3/download/eventemitter3-3.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-3.1.2.tgz",
       "integrity": "sha1-LT1I+cNGaY/Og6hdfWZOmFNd9uc=",
       "dev": true
     },
     "events": {
       "version": "3.0.0",
-      "resolved": "https://registry.npm.taobao.org/events/download/events-3.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/events/-/events-3.0.0.tgz",
       "integrity": "sha1-mgoN+vYok9krh1uPJpjKQRSXPog=",
       "dev": true
     },
     "eventsource": {
       "version": "1.0.7",
-      "resolved": "https://registry.npm.taobao.org/eventsource/download/eventsource-1.0.7.tgz",
+      "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-1.0.7.tgz",
       "integrity": "sha1-j7xyyT/NNAiAkLwKTmT0tc7m2NA=",
       "dev": true,
       "requires": {
@@ -4482,7 +4482,7 @@
     },
     "evp_bytestokey": {
       "version": "1.0.3",
-      "resolved": "https://registry.npm.taobao.org/evp_bytestokey/download/evp_bytestokey-1.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/evp_bytestokey/-/evp_bytestokey-1.0.3.tgz",
       "integrity": "sha1-f8vbGY3HGVlDLv4ThCaE4FJaywI=",
       "dev": true,
       "requires": {
@@ -4492,7 +4492,7 @@
     },
     "execa": {
       "version": "1.0.0",
-      "resolved": "https://registry.npm.taobao.org/execa/download/execa-1.0.0.tgz?cache=0&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fexeca%2Fdownload%2Fexeca-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-1.0.0.tgz",
       "integrity": "sha1-xiNqW7TfbW8V6I5/AXeYIWdJ3dg=",
       "dev": true,
       "requires": {
@@ -4507,7 +4507,7 @@
     },
     "expand-brackets": {
       "version": "2.1.4",
-      "resolved": "https://registry.npm.taobao.org/expand-brackets/download/expand-brackets-2.1.4.tgz",
+      "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-2.1.4.tgz",
       "integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
       "dev": true,
       "requires": {
@@ -4522,7 +4522,7 @@
       "dependencies": {
         "debug": {
           "version": "2.6.9",
-          "resolved": "https://registry.npm.taobao.org/debug/download/debug-2.6.9.tgz",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
           "integrity": "sha1-XRKFFd8TT/Mn6QpMk/Tgd6U2NB8=",
           "dev": true,
           "requires": {
@@ -4531,7 +4531,7 @@
         },
         "define-property": {
           "version": "0.2.5",
-          "resolved": "https://registry.npm.taobao.org/define-property/download/define-property-0.2.5.tgz",
+          "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
           "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
           "dev": true,
           "requires": {
@@ -4540,7 +4540,7 @@
         },
         "extend-shallow": {
           "version": "2.0.1",
-          "resolved": "https://registry.npm.taobao.org/extend-shallow/download/extend-shallow-2.0.1.tgz",
+          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
           "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
           "dev": true,
           "requires": {
@@ -4549,7 +4549,7 @@
         },
         "ms": {
           "version": "2.0.0",
-          "resolved": "https://registry.npm.taobao.org/ms/download/ms-2.0.0.tgz?cache=0&sync_timestamp=1559842528856&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fms%2Fdownload%2Fms-2.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
           "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
           "dev": true
         }
@@ -4557,7 +4557,7 @@
     },
     "express": {
       "version": "4.17.1",
-      "resolved": "https://registry.npm.taobao.org/express/download/express-4.17.1.tgz",
+      "resolved": "https://registry.npmjs.org/express/-/express-4.17.1.tgz",
       "integrity": "sha1-RJH8OGBc9R+GKdOcK10Cb5ikwTQ=",
       "dev": true,
       "requires": {
@@ -4595,7 +4595,7 @@
       "dependencies": {
         "debug": {
           "version": "2.6.9",
-          "resolved": "https://registry.npm.taobao.org/debug/download/debug-2.6.9.tgz",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
           "integrity": "sha1-XRKFFd8TT/Mn6QpMk/Tgd6U2NB8=",
           "dev": true,
           "requires": {
@@ -4604,13 +4604,13 @@
         },
         "ms": {
           "version": "2.0.0",
-          "resolved": "https://registry.npm.taobao.org/ms/download/ms-2.0.0.tgz?cache=0&sync_timestamp=1559842528856&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fms%2Fdownload%2Fms-2.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
           "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
           "dev": true
         },
         "qs": {
           "version": "6.7.0",
-          "resolved": "https://registry.npm.taobao.org/qs/download/qs-6.7.0.tgz",
+          "resolved": "https://registry.npmjs.org/qs/-/qs-6.7.0.tgz",
           "integrity": "sha1-QdwaAV49WB8WIXdr4xr7KHapsbw=",
           "dev": true
         }
@@ -4618,13 +4618,13 @@
     },
     "extend": {
       "version": "3.0.2",
-      "resolved": "https://registry.npm.taobao.org/extend/download/extend-3.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
       "integrity": "sha1-+LETa0Bx+9jrFAr/hYsQGewpFfo=",
       "dev": true
     },
     "extend-shallow": {
       "version": "3.0.2",
-      "resolved": "https://registry.npm.taobao.org/extend-shallow/download/extend-shallow-3.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-3.0.2.tgz",
       "integrity": "sha1-Jqcarwc7OfshJxcnRhMcJwQCjbg=",
       "dev": true,
       "requires": {
@@ -4634,7 +4634,7 @@
       "dependencies": {
         "is-extendable": {
           "version": "1.0.1",
-          "resolved": "https://registry.npm.taobao.org/is-extendable/download/is-extendable-1.0.1.tgz",
+          "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
           "integrity": "sha1-p0cPnkJnM9gb2B4RVSZOOjUHyrQ=",
           "dev": true,
           "requires": {
@@ -4645,7 +4645,7 @@
     },
     "external-editor": {
       "version": "2.2.0",
-      "resolved": "https://registry.npm.taobao.org/external-editor/download/external-editor-2.2.0.tgz?cache=0&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fexternal-editor%2Fdownload%2Fexternal-editor-2.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-2.2.0.tgz",
       "integrity": "sha1-BFURz9jRM/OEZnPRBHwVTiFK09U=",
       "dev": true,
       "optional": true,
@@ -4657,7 +4657,7 @@
     },
     "extglob": {
       "version": "2.0.4",
-      "resolved": "https://registry.npm.taobao.org/extglob/download/extglob-2.0.4.tgz",
+      "resolved": "https://registry.npmjs.org/extglob/-/extglob-2.0.4.tgz",
       "integrity": "sha1-rQD+TcYSqSMuhxhxHcXLWrAoVUM=",
       "dev": true,
       "requires": {
@@ -4673,7 +4673,7 @@
       "dependencies": {
         "define-property": {
           "version": "1.0.0",
-          "resolved": "https://registry.npm.taobao.org/define-property/download/define-property-1.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
           "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
           "dev": true,
           "requires": {
@@ -4682,7 +4682,7 @@
         },
         "extend-shallow": {
           "version": "2.0.1",
-          "resolved": "https://registry.npm.taobao.org/extend-shallow/download/extend-shallow-2.0.1.tgz",
+          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
           "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
           "dev": true,
           "requires": {
@@ -4691,7 +4691,7 @@
         },
         "is-accessor-descriptor": {
           "version": "1.0.0",
-          "resolved": "https://registry.npm.taobao.org/is-accessor-descriptor/download/is-accessor-descriptor-1.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
           "integrity": "sha1-FpwvbT3x+ZJhgHI2XJsOofaHhlY=",
           "dev": true,
           "requires": {
@@ -4700,7 +4700,7 @@
         },
         "is-data-descriptor": {
           "version": "1.0.0",
-          "resolved": "https://registry.npm.taobao.org/is-data-descriptor/download/is-data-descriptor-1.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
           "integrity": "sha1-2Eh2Mh0Oet0DmQQGq7u9NrqSaMc=",
           "dev": true,
           "requires": {
@@ -4709,7 +4709,7 @@
         },
         "is-descriptor": {
           "version": "1.0.2",
-          "resolved": "https://registry.npm.taobao.org/is-descriptor/download/is-descriptor-1.0.2.tgz",
+          "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
           "integrity": "sha1-OxWXRqZmBLBPjIFSS6NlxfFNhuw=",
           "dev": true,
           "requires": {
@@ -4722,19 +4722,19 @@
     },
     "extsprintf": {
       "version": "1.3.0",
-      "resolved": "https://registry.npm.taobao.org/extsprintf/download/extsprintf-1.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
       "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU=",
       "dev": true
     },
     "fast-deep-equal": {
       "version": "2.0.1",
-      "resolved": "https://registry.npm.taobao.org/fast-deep-equal/download/fast-deep-equal-2.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
       "integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk=",
       "dev": true
     },
     "fast-glob": {
       "version": "2.2.7",
-      "resolved": "https://registry.npm.taobao.org/fast-glob/download/fast-glob-2.2.7.tgz",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-2.2.7.tgz",
       "integrity": "sha1-aVOFfDr6R1//ku5gFdUtpwpM050=",
       "dev": true,
       "requires": {
@@ -4748,25 +4748,25 @@
     },
     "fast-json-stable-stringify": {
       "version": "2.0.0",
-      "resolved": "https://registry.npm.taobao.org/fast-json-stable-stringify/download/fast-json-stable-stringify-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
       "integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I=",
       "dev": true
     },
     "fast-levenshtein": {
       "version": "2.0.6",
-      "resolved": "https://registry.npm.taobao.org/fast-levenshtein/download/fast-levenshtein-2.0.6.tgz",
+      "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
       "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
       "dev": true
     },
     "fastparse": {
       "version": "1.1.2",
-      "resolved": "https://registry.npm.taobao.org/fastparse/download/fastparse-1.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/fastparse/-/fastparse-1.1.2.tgz",
       "integrity": "sha1-kXKMWllC7O2FMSg8eUQe5BIsNak=",
       "dev": true
     },
     "faye-websocket": {
       "version": "0.10.0",
-      "resolved": "https://registry.npm.taobao.org/faye-websocket/download/faye-websocket-0.10.0.tgz",
+      "resolved": "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.10.0.tgz",
       "integrity": "sha1-TkkvjQTftviQA1B/btvy1QHnxvQ=",
       "dev": true,
       "requires": {
@@ -4775,13 +4775,13 @@
     },
     "figgy-pudding": {
       "version": "3.5.1",
-      "resolved": "https://registry.npm.taobao.org/figgy-pudding/download/figgy-pudding-3.5.1.tgz",
+      "resolved": "https://registry.npmjs.org/figgy-pudding/-/figgy-pudding-3.5.1.tgz",
       "integrity": "sha1-hiRwESkBxyeg5JWoB0S9W6odZ5A=",
       "dev": true
     },
     "figures": {
       "version": "2.0.0",
-      "resolved": "https://registry.npm.taobao.org/figures/download/figures-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/figures/-/figures-2.0.0.tgz",
       "integrity": "sha1-OrGi0qYsi/tDGgyUy3l6L84nyWI=",
       "dev": true,
       "requires": {
@@ -4790,7 +4790,7 @@
     },
     "file-entry-cache": {
       "version": "2.0.0",
-      "resolved": "https://registry.npm.taobao.org/file-entry-cache/download/file-entry-cache-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-2.0.0.tgz",
       "integrity": "sha1-w5KZDD5oR4PYOLjISkXYoEhFg2E=",
       "dev": true,
       "optional": true,
@@ -4801,7 +4801,7 @@
     },
     "file-loader": {
       "version": "3.0.1",
-      "resolved": "https://registry.npm.taobao.org/file-loader/download/file-loader-3.0.1.tgz?cache=0&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Ffile-loader%2Fdownload%2Ffile-loader-3.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/file-loader/-/file-loader-3.0.1.tgz",
       "integrity": "sha1-+OC6C1mZGLUa3+RdZtHnca1WD6o=",
       "dev": true,
       "requires": {
@@ -4811,7 +4811,7 @@
       "dependencies": {
         "schema-utils": {
           "version": "1.0.0",
-          "resolved": "https://registry.npm.taobao.org/schema-utils/download/schema-utils-1.0.0.tgz?cache=0&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fschema-utils%2Fdownload%2Fschema-utils-1.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-1.0.0.tgz",
           "integrity": "sha1-C3mpMgTXtgDUsoUNH2bCo0lRx3A=",
           "dev": true,
           "requires": {
@@ -4824,13 +4824,13 @@
     },
     "filesize": {
       "version": "3.6.1",
-      "resolved": "https://registry.npm.taobao.org/filesize/download/filesize-3.6.1.tgz?cache=0&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Ffilesize%2Fdownload%2Ffilesize-3.6.1.tgz",
+      "resolved": "https://registry.npmjs.org/filesize/-/filesize-3.6.1.tgz",
       "integrity": "sha1-CQuz7gG2+AGoqL6Z0xcQs0Irsxc=",
       "dev": true
     },
     "fill-range": {
       "version": "4.0.0",
-      "resolved": "https://registry.npm.taobao.org/fill-range/download/fill-range-4.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
       "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
       "dev": true,
       "requires": {
@@ -4842,7 +4842,7 @@
       "dependencies": {
         "extend-shallow": {
           "version": "2.0.1",
-          "resolved": "https://registry.npm.taobao.org/extend-shallow/download/extend-shallow-2.0.1.tgz",
+          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
           "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
           "dev": true,
           "requires": {
@@ -4853,7 +4853,7 @@
     },
     "finalhandler": {
       "version": "1.1.2",
-      "resolved": "https://registry.npm.taobao.org/finalhandler/download/finalhandler-1.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.1.2.tgz",
       "integrity": "sha1-t+fQAP/RGTjQ/bBTUG9uur6fWH0=",
       "dev": true,
       "requires": {
@@ -4868,7 +4868,7 @@
       "dependencies": {
         "debug": {
           "version": "2.6.9",
-          "resolved": "https://registry.npm.taobao.org/debug/download/debug-2.6.9.tgz",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
           "integrity": "sha1-XRKFFd8TT/Mn6QpMk/Tgd6U2NB8=",
           "dev": true,
           "requires": {
@@ -4877,7 +4877,7 @@
         },
         "ms": {
           "version": "2.0.0",
-          "resolved": "https://registry.npm.taobao.org/ms/download/ms-2.0.0.tgz?cache=0&sync_timestamp=1559842528856&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fms%2Fdownload%2Fms-2.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
           "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
           "dev": true
         }
@@ -4885,7 +4885,7 @@
     },
     "find-babel-config": {
       "version": "1.2.0",
-      "resolved": "https://registry.npm.taobao.org/find-babel-config/download/find-babel-config-1.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/find-babel-config/-/find-babel-config-1.2.0.tgz",
       "integrity": "sha1-qbezF+tbmGDNqdVHQKjIM3oig6I=",
       "dev": true,
       "requires": {
@@ -4895,7 +4895,7 @@
       "dependencies": {
         "json5": {
           "version": "0.5.1",
-          "resolved": "https://registry.npm.taobao.org/json5/download/json5-0.5.1.tgz?cache=0&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fjson5%2Fdownload%2Fjson5-0.5.1.tgz",
+          "resolved": "https://registry.npmjs.org/json5/-/json5-0.5.1.tgz",
           "integrity": "sha1-Hq3nrMASA0rYTiOWdn6tn6VJWCE=",
           "dev": true
         }
@@ -4903,7 +4903,7 @@
     },
     "find-cache-dir": {
       "version": "2.1.0",
-      "resolved": "https://registry.npm.taobao.org/find-cache-dir/download/find-cache-dir-2.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-2.1.0.tgz",
       "integrity": "sha1-jQ+UzRP+Q8bHwmGg2GEVypGMBfc=",
       "dev": true,
       "requires": {
@@ -4914,7 +4914,7 @@
     },
     "find-up": {
       "version": "2.1.0",
-      "resolved": "https://registry.npm.taobao.org/find-up/download/find-up-2.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
       "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
       "dev": true,
       "requires": {
@@ -4923,7 +4923,7 @@
     },
     "flat-cache": {
       "version": "1.3.4",
-      "resolved": "https://registry.npm.taobao.org/flat-cache/download/flat-cache-1.3.4.tgz",
+      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-1.3.4.tgz",
       "integrity": "sha1-LC73dSXMKSkAff/6HdMUqpyd7m8=",
       "dev": true,
       "optional": true,
@@ -4936,13 +4936,13 @@
     },
     "flatted": {
       "version": "2.0.1",
-      "resolved": "https://registry.npm.taobao.org/flatted/download/flatted-2.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-2.0.1.tgz",
       "integrity": "sha1-aeV8qo8OrLwoHS4stFjUb9tEngg=",
       "dev": true
     },
     "flush-write-stream": {
       "version": "1.1.1",
-      "resolved": "https://registry.npm.taobao.org/flush-write-stream/download/flush-write-stream-1.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/flush-write-stream/-/flush-write-stream-1.1.1.tgz",
       "integrity": "sha1-jdfYc6G6vCB9lOrQwuDkQnbr8ug=",
       "dev": true,
       "requires": {
@@ -4952,7 +4952,7 @@
     },
     "follow-redirects": {
       "version": "1.7.0",
-      "resolved": "https://registry.npm.taobao.org/follow-redirects/download/follow-redirects-1.7.0.tgz",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.7.0.tgz",
       "integrity": "sha1-SJ68GY3A5/ZBZ70jsDxMGbV4THY=",
       "dev": true,
       "requires": {
@@ -4961,7 +4961,7 @@
       "dependencies": {
         "debug": {
           "version": "3.2.6",
-          "resolved": "https://registry.npm.taobao.org/debug/download/debug-3.2.6.tgz",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
           "integrity": "sha1-6D0X3hbYp++3cX7b5fsQE17uYps=",
           "dev": true,
           "requires": {
@@ -4972,19 +4972,19 @@
     },
     "for-in": {
       "version": "1.0.2",
-      "resolved": "https://registry.npm.taobao.org/for-in/download/for-in-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
       "integrity": "sha1-gQaNKVqBQuwKxybG4iAMMPttXoA=",
       "dev": true
     },
     "forever-agent": {
       "version": "0.6.1",
-      "resolved": "https://registry.npm.taobao.org/forever-agent/download/forever-agent-0.6.1.tgz",
+      "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
       "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=",
       "dev": true
     },
     "form-data": {
       "version": "2.3.3",
-      "resolved": "https://registry.npm.taobao.org/form-data/download/form-data-2.3.3.tgz",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.3.tgz",
       "integrity": "sha1-3M5SwF9kTymManq5Nr1yTO/786Y=",
       "dev": true,
       "requires": {
@@ -4995,13 +4995,13 @@
     },
     "forwarded": {
       "version": "0.1.2",
-      "resolved": "https://registry.npm.taobao.org/forwarded/download/forwarded-0.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.1.2.tgz",
       "integrity": "sha1-mMI9qxF1ZXuMBXPozszZGw/xjIQ=",
       "dev": true
     },
     "fragment-cache": {
       "version": "0.2.1",
-      "resolved": "https://registry.npm.taobao.org/fragment-cache/download/fragment-cache-0.2.1.tgz",
+      "resolved": "https://registry.npmjs.org/fragment-cache/-/fragment-cache-0.2.1.tgz",
       "integrity": "sha1-QpD60n8T6Jvn8zeZxrxaCr//DRk=",
       "dev": true,
       "requires": {
@@ -5010,13 +5010,13 @@
     },
     "fresh": {
       "version": "0.5.2",
-      "resolved": "https://registry.npm.taobao.org/fresh/download/fresh-0.5.2.tgz",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
       "integrity": "sha1-PYyt2Q2XZWn6g1qx+OSyOhBWBac=",
       "dev": true
     },
     "from2": {
       "version": "2.3.0",
-      "resolved": "https://registry.npm.taobao.org/from2/download/from2-2.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/from2/-/from2-2.3.0.tgz",
       "integrity": "sha1-i/tVAr3kpNNs/e6gB/zKIdfjgq8=",
       "dev": true,
       "requires": {
@@ -5026,7 +5026,7 @@
     },
     "fs-extra": {
       "version": "7.0.1",
-      "resolved": "https://registry.npm.taobao.org/fs-extra/download/fs-extra-7.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-7.0.1.tgz",
       "integrity": "sha1-TxicRKoSO4lfcigE9V6iPq3DSOk=",
       "dev": true,
       "requires": {
@@ -5037,7 +5037,7 @@
     },
     "fs-write-stream-atomic": {
       "version": "1.0.10",
-      "resolved": "https://registry.npm.taobao.org/fs-write-stream-atomic/download/fs-write-stream-atomic-1.0.10.tgz",
+      "resolved": "https://registry.npmjs.org/fs-write-stream-atomic/-/fs-write-stream-atomic-1.0.10.tgz",
       "integrity": "sha1-tH31NJPvkR33VzHnCp3tAYnbQMk=",
       "dev": true,
       "requires": {
@@ -5049,13 +5049,13 @@
     },
     "fs.realpath": {
       "version": "1.0.0",
-      "resolved": "https://registry.npm.taobao.org/fs.realpath/download/fs.realpath-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
       "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
       "dev": true
     },
     "fsevents": {
       "version": "1.2.9",
-      "resolved": "https://registry.npm.taobao.org/fsevents/download/fsevents-1.2.9.tgz",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.9.tgz",
       "integrity": "sha1-P17WZYPM1vQAtaANtvfoYTY+OI8=",
       "dev": true,
       "optional": true,
@@ -5603,25 +5603,25 @@
     },
     "function-bind": {
       "version": "1.1.1",
-      "resolved": "https://registry.npm.taobao.org/function-bind/download/function-bind-1.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
       "integrity": "sha1-pWiZ0+o8m6uHS7l3O3xe3pL0iV0=",
       "dev": true
     },
     "functional-red-black-tree": {
       "version": "1.0.1",
-      "resolved": "https://registry.npm.taobao.org/functional-red-black-tree/download/functional-red-black-tree-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
       "integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=",
       "dev": true
     },
     "get-caller-file": {
       "version": "2.0.5",
-      "resolved": "https://registry.npm.taobao.org/get-caller-file/download/get-caller-file-2.0.5.tgz",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
       "integrity": "sha1-T5RBKoLbMvNuOwuXQfipf+sDH34=",
       "dev": true
     },
     "get-stream": {
       "version": "4.1.0",
-      "resolved": "https://registry.npm.taobao.org/get-stream/download/get-stream-4.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-4.1.0.tgz",
       "integrity": "sha1-wbJVV189wh1Zv8ec09K0axw6VLU=",
       "dev": true,
       "requires": {
@@ -5630,13 +5630,13 @@
     },
     "get-value": {
       "version": "2.0.6",
-      "resolved": "https://registry.npm.taobao.org/get-value/download/get-value-2.0.6.tgz",
+      "resolved": "https://registry.npmjs.org/get-value/-/get-value-2.0.6.tgz",
       "integrity": "sha1-3BXKHGcjh8p2vTesCjlbogQqLCg=",
       "dev": true
     },
     "getpass": {
       "version": "0.1.7",
-      "resolved": "https://registry.npm.taobao.org/getpass/download/getpass-0.1.7.tgz",
+      "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
       "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
       "dev": true,
       "requires": {
@@ -5645,7 +5645,7 @@
     },
     "glob": {
       "version": "7.1.4",
-      "resolved": "https://registry.npm.taobao.org/glob/download/glob-7.1.4.tgz",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.4.tgz",
       "integrity": "sha1-qmCKL2xXetNX4a5aXCbZqNGWklU=",
       "dev": true,
       "requires": {
@@ -5659,7 +5659,7 @@
     },
     "glob-parent": {
       "version": "3.1.0",
-      "resolved": "https://registry.npm.taobao.org/glob-parent/download/glob-parent-3.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-3.1.0.tgz",
       "integrity": "sha1-nmr2KZ2NO9K9QEMIMr0RPfkGxa4=",
       "dev": true,
       "requires": {
@@ -5669,7 +5669,7 @@
       "dependencies": {
         "is-glob": {
           "version": "3.1.0",
-          "resolved": "https://registry.npm.taobao.org/is-glob/download/is-glob-3.1.0.tgz",
+          "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
           "integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
           "dev": true,
           "requires": {
@@ -5680,19 +5680,19 @@
     },
     "glob-to-regexp": {
       "version": "0.3.0",
-      "resolved": "https://registry.npm.taobao.org/glob-to-regexp/download/glob-to-regexp-0.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/glob-to-regexp/-/glob-to-regexp-0.3.0.tgz",
       "integrity": "sha1-jFoUlNIGbFcMw7/kSWF1rMTVAqs=",
       "dev": true
     },
     "globals": {
       "version": "11.12.0",
-      "resolved": "https://registry.npm.taobao.org/globals/download/globals-11.12.0.tgz",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
       "integrity": "sha1-q4eVM4hooLq9hSV1gBjCp+uVxC4=",
       "dev": true
     },
     "globby": {
       "version": "9.2.0",
-      "resolved": "https://registry.npm.taobao.org/globby/download/globby-9.2.0.tgz?cache=0&sync_timestamp=1562307970751&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fglobby%2Fdownload%2Fglobby-9.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/globby/-/globby-9.2.0.tgz",
       "integrity": "sha1-/QKacGxwPSm90XD0tts6P3p8tj0=",
       "dev": true,
       "requires": {
@@ -5708,7 +5708,7 @@
       "dependencies": {
         "ignore": {
           "version": "4.0.6",
-          "resolved": "https://registry.npm.taobao.org/ignore/download/ignore-4.0.6.tgz",
+          "resolved": "https://registry.npmjs.org/ignore/-/ignore-4.0.6.tgz",
           "integrity": "sha1-dQ49tYYgh7RzfrrIIH/9HvJ7Jfw=",
           "dev": true
         }
@@ -5716,13 +5716,13 @@
     },
     "graceful-fs": {
       "version": "4.2.1",
-      "resolved": "https://registry.npm.taobao.org/graceful-fs/download/graceful-fs-4.2.1.tgz?cache=0&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fgraceful-fs%2Fdownload%2Fgraceful-fs-4.2.1.tgz",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.1.tgz",
       "integrity": "sha1-HB8MNkiCyGj1v/ZRIUYygzahGx0=",
       "dev": true
     },
     "gzip-size": {
       "version": "5.1.1",
-      "resolved": "https://registry.npm.taobao.org/gzip-size/download/gzip-size-5.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/gzip-size/-/gzip-size-5.1.1.tgz",
       "integrity": "sha1-y5vuaS+HwGErIyhAqHOQTkwTUnQ=",
       "dev": true,
       "requires": {
@@ -5732,19 +5732,19 @@
     },
     "handle-thing": {
       "version": "2.0.0",
-      "resolved": "https://registry.npm.taobao.org/handle-thing/download/handle-thing-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/handle-thing/-/handle-thing-2.0.0.tgz",
       "integrity": "sha1-DgOWlf9QyT/CiFV9aW88HcZ3Z1Q=",
       "dev": true
     },
     "har-schema": {
       "version": "2.0.0",
-      "resolved": "https://registry.npm.taobao.org/har-schema/download/har-schema-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
       "integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI=",
       "dev": true
     },
     "har-validator": {
       "version": "5.1.3",
-      "resolved": "https://registry.npm.taobao.org/har-validator/download/har-validator-5.1.3.tgz",
+      "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.3.tgz",
       "integrity": "sha1-HvievT5JllV2de7ZiTEQ3DUPoIA=",
       "dev": true,
       "requires": {
@@ -5754,7 +5754,7 @@
     },
     "has": {
       "version": "1.0.3",
-      "resolved": "https://registry.npm.taobao.org/has/download/has-1.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
       "integrity": "sha1-ci18v8H2qoJB8W3YFOAR4fQeh5Y=",
       "dev": true,
       "requires": {
@@ -5763,7 +5763,7 @@
     },
     "has-ansi": {
       "version": "2.0.0",
-      "resolved": "https://registry.npm.taobao.org/has-ansi/download/has-ansi-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
       "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
       "dev": true,
       "requires": {
@@ -5772,7 +5772,7 @@
       "dependencies": {
         "ansi-regex": {
           "version": "2.1.1",
-          "resolved": "https://registry.npm.taobao.org/ansi-regex/download/ansi-regex-2.1.1.tgz",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
           "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
           "dev": true
         }
@@ -5780,19 +5780,19 @@
     },
     "has-flag": {
       "version": "3.0.0",
-      "resolved": "https://registry.npm.taobao.org/has-flag/download/has-flag-3.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
       "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
       "dev": true
     },
     "has-symbols": {
       "version": "1.0.0",
-      "resolved": "https://registry.npm.taobao.org/has-symbols/download/has-symbols-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.0.tgz",
       "integrity": "sha1-uhqPGvKg/DllD1yFA2dwQSIGO0Q=",
       "dev": true
     },
     "has-value": {
       "version": "1.0.0",
-      "resolved": "https://registry.npm.taobao.org/has-value/download/has-value-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/has-value/-/has-value-1.0.0.tgz",
       "integrity": "sha1-GLKB2lhbHFxR3vJMkw7SmgvmsXc=",
       "dev": true,
       "requires": {
@@ -5803,7 +5803,7 @@
     },
     "has-values": {
       "version": "1.0.0",
-      "resolved": "https://registry.npm.taobao.org/has-values/download/has-values-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/has-values/-/has-values-1.0.0.tgz",
       "integrity": "sha1-lbC2P+whRmGab+V/51Yo1aOe/k8=",
       "dev": true,
       "requires": {
@@ -5813,7 +5813,7 @@
       "dependencies": {
         "kind-of": {
           "version": "4.0.0",
-          "resolved": "https://registry.npm.taobao.org/kind-of/download/kind-of-4.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-4.0.0.tgz",
           "integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
           "dev": true,
           "requires": {
@@ -5824,7 +5824,7 @@
     },
     "hash-base": {
       "version": "3.0.4",
-      "resolved": "https://registry.npm.taobao.org/hash-base/download/hash-base-3.0.4.tgz",
+      "resolved": "https://registry.npmjs.org/hash-base/-/hash-base-3.0.4.tgz",
       "integrity": "sha1-X8hoaEfs1zSZQDMZprCj8/auSRg=",
       "dev": true,
       "requires": {
@@ -5834,13 +5834,13 @@
     },
     "hash-sum": {
       "version": "1.0.2",
-      "resolved": "https://registry.npm.taobao.org/hash-sum/download/hash-sum-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/hash-sum/-/hash-sum-1.0.2.tgz",
       "integrity": "sha1-M7QHd3VMZDJXPBIMw4CLvRDUfwQ=",
       "dev": true
     },
     "hash.js": {
       "version": "1.1.7",
-      "resolved": "https://registry.npm.taobao.org/hash.js/download/hash.js-1.1.7.tgz",
+      "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.7.tgz",
       "integrity": "sha1-C6vKU46NTuSg+JiNaIZlN6ADz0I=",
       "dev": true,
       "requires": {
@@ -5850,25 +5850,25 @@
     },
     "he": {
       "version": "1.2.0",
-      "resolved": "https://registry.npm.taobao.org/he/download/he-1.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
       "integrity": "sha1-hK5l+n6vsWX922FWauFLrwVmTw8=",
       "dev": true
     },
     "hex-color-regex": {
       "version": "1.1.0",
-      "resolved": "https://registry.npm.taobao.org/hex-color-regex/download/hex-color-regex-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/hex-color-regex/-/hex-color-regex-1.1.0.tgz",
       "integrity": "sha1-TAb8y0YC/iYCs8k9+C1+fb8aio4=",
       "dev": true
     },
     "highlight.js": {
       "version": "9.15.9",
-      "resolved": "https://registry.npm.taobao.org/highlight.js/download/highlight.js-9.15.9.tgz",
+      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-9.15.9.tgz",
       "integrity": "sha1-hlJX2h27SljEVS1GxLOFT3fw5tU=",
       "dev": true
     },
     "hmac-drbg": {
       "version": "1.0.1",
-      "resolved": "https://registry.npm.taobao.org/hmac-drbg/download/hmac-drbg-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/hmac-drbg/-/hmac-drbg-1.0.1.tgz",
       "integrity": "sha1-0nRXAQJabHdabFRXk+1QL8DGSaE=",
       "dev": true,
       "requires": {
@@ -5879,13 +5879,13 @@
     },
     "hoopy": {
       "version": "0.1.4",
-      "resolved": "https://registry.npm.taobao.org/hoopy/download/hoopy-0.1.4.tgz",
+      "resolved": "https://registry.npmjs.org/hoopy/-/hoopy-0.1.4.tgz",
       "integrity": "sha1-YJIH1mEQADOpqUAq096mdzgcGx0=",
       "dev": true
     },
     "hosted-git-info": {
       "version": "2.8.2",
-      "resolved": "https://registry.npm.taobao.org/hosted-git-info/download/hosted-git-info-2.8.2.tgz",
+      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.2.tgz",
       "integrity": "sha1-o1w/NVrBJJ8Qk8DCpUKs6IGMFxo=",
       "dev": true,
       "requires": {
@@ -5894,7 +5894,7 @@
     },
     "hpack.js": {
       "version": "2.1.6",
-      "resolved": "https://registry.npm.taobao.org/hpack.js/download/hpack.js-2.1.6.tgz",
+      "resolved": "https://registry.npmjs.org/hpack.js/-/hpack.js-2.1.6.tgz",
       "integrity": "sha1-h3dMCUnlE/QuhFdbPEVoH63ioLI=",
       "dev": true,
       "requires": {
@@ -5906,31 +5906,31 @@
     },
     "hsl-regex": {
       "version": "1.0.0",
-      "resolved": "https://registry.npm.taobao.org/hsl-regex/download/hsl-regex-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/hsl-regex/-/hsl-regex-1.0.0.tgz",
       "integrity": "sha1-1JMwx4ntgZ4nakwNJy3/owsY/m4=",
       "dev": true
     },
     "hsla-regex": {
       "version": "1.0.0",
-      "resolved": "https://registry.npm.taobao.org/hsla-regex/download/hsla-regex-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/hsla-regex/-/hsla-regex-1.0.0.tgz",
       "integrity": "sha1-wc56MWjIxmFAM6S194d/OyJfnDg=",
       "dev": true
     },
     "html-comment-regex": {
       "version": "1.1.2",
-      "resolved": "https://registry.npm.taobao.org/html-comment-regex/download/html-comment-regex-1.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/html-comment-regex/-/html-comment-regex-1.1.2.tgz",
       "integrity": "sha1-l9RoiutcgYhqNk+qDK0d2hTUM6c=",
       "dev": true
     },
     "html-entities": {
       "version": "1.2.1",
-      "resolved": "https://registry.npm.taobao.org/html-entities/download/html-entities-1.2.1.tgz",
+      "resolved": "https://registry.npmjs.org/html-entities/-/html-entities-1.2.1.tgz",
       "integrity": "sha1-DfKTUfByEWNRXfueVUPl9u7VFi8=",
       "dev": true
     },
     "html-minifier": {
       "version": "3.5.21",
-      "resolved": "https://registry.npm.taobao.org/html-minifier/download/html-minifier-3.5.21.tgz",
+      "resolved": "https://registry.npmjs.org/html-minifier/-/html-minifier-3.5.21.tgz",
       "integrity": "sha1-0AQOBUcw41TbAIRjWTGUAVIS0gw=",
       "dev": true,
       "requires": {
@@ -5945,7 +5945,7 @@
       "dependencies": {
         "commander": {
           "version": "2.17.1",
-          "resolved": "https://registry.npm.taobao.org/commander/download/commander-2.17.1.tgz?cache=0&sync_timestamp=1565398176321&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fcommander%2Fdownload%2Fcommander-2.17.1.tgz",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.17.1.tgz",
           "integrity": "sha1-vXerfebelCBc6sxy8XFtKfIKd78=",
           "dev": true
         }
@@ -5953,13 +5953,13 @@
     },
     "html-tags": {
       "version": "2.0.0",
-      "resolved": "https://registry.npm.taobao.org/html-tags/download/html-tags-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/html-tags/-/html-tags-2.0.0.tgz",
       "integrity": "sha1-ELMKOGCF9Dzt41PMj6fLDe7qZos=",
       "dev": true
     },
     "html-webpack-plugin": {
       "version": "3.2.0",
-      "resolved": "https://registry.npm.taobao.org/html-webpack-plugin/download/html-webpack-plugin-3.2.0.tgz?cache=0&sync_timestamp=1563437816811&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fhtml-webpack-plugin%2Fdownload%2Fhtml-webpack-plugin-3.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/html-webpack-plugin/-/html-webpack-plugin-3.2.0.tgz",
       "integrity": "sha1-sBq71yOsqqeze2r0SS69oD2d03s=",
       "dev": true,
       "requires": {
@@ -5974,19 +5974,19 @@
       "dependencies": {
         "big.js": {
           "version": "3.2.0",
-          "resolved": "https://registry.npm.taobao.org/big.js/download/big.js-3.2.0.tgz",
+          "resolved": "https://registry.npmjs.org/big.js/-/big.js-3.2.0.tgz",
           "integrity": "sha1-pfwpi4G54Nyi5FiCR4S2XFK6WI4=",
           "dev": true
         },
         "json5": {
           "version": "0.5.1",
-          "resolved": "https://registry.npm.taobao.org/json5/download/json5-0.5.1.tgz?cache=0&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fjson5%2Fdownload%2Fjson5-0.5.1.tgz",
+          "resolved": "https://registry.npmjs.org/json5/-/json5-0.5.1.tgz",
           "integrity": "sha1-Hq3nrMASA0rYTiOWdn6tn6VJWCE=",
           "dev": true
         },
         "loader-utils": {
           "version": "0.2.17",
-          "resolved": "https://registry.npm.taobao.org/loader-utils/download/loader-utils-0.2.17.tgz",
+          "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-0.2.17.tgz",
           "integrity": "sha1-+G5jdNQyBabmxg6RlvF8Apm/s0g=",
           "dev": true,
           "requires": {
@@ -6000,7 +6000,7 @@
     },
     "htmlparser2": {
       "version": "3.10.1",
-      "resolved": "https://registry.npm.taobao.org/htmlparser2/download/htmlparser2-3.10.1.tgz",
+      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.10.1.tgz",
       "integrity": "sha1-vWedw/WYl7ajS7EHSchVu1OpOS8=",
       "dev": true,
       "requires": {
@@ -6014,13 +6014,13 @@
       "dependencies": {
         "entities": {
           "version": "1.1.2",
-          "resolved": "https://registry.npm.taobao.org/entities/download/entities-1.1.2.tgz?cache=0&sync_timestamp=1563403318326&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fentities%2Fdownload%2Fentities-1.1.2.tgz",
+          "resolved": "https://registry.npmjs.org/entities/-/entities-1.1.2.tgz",
           "integrity": "sha1-vfpzUplmTfr9NFKe1PhSKidf6lY=",
           "dev": true
         },
         "readable-stream": {
           "version": "3.4.0",
-          "resolved": "https://registry.npm.taobao.org/readable-stream/download/readable-stream-3.4.0.tgz",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.4.0.tgz",
           "integrity": "sha1-pRwmdUZY4KPCHb9ZFjvUW6b0R/w=",
           "dev": true,
           "requires": {
@@ -6033,13 +6033,13 @@
     },
     "http-deceiver": {
       "version": "1.2.7",
-      "resolved": "https://registry.npm.taobao.org/http-deceiver/download/http-deceiver-1.2.7.tgz",
+      "resolved": "https://registry.npmjs.org/http-deceiver/-/http-deceiver-1.2.7.tgz",
       "integrity": "sha1-+nFolEq5pRnTN8sL7HKE3D5yPYc=",
       "dev": true
     },
     "http-errors": {
       "version": "1.7.2",
-      "resolved": "https://registry.npm.taobao.org/http-errors/download/http-errors-1.7.2.tgz",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.7.2.tgz",
       "integrity": "sha1-T1ApzxMjnzEDblsuVSkrz7zIXI8=",
       "dev": true,
       "requires": {
@@ -6052,7 +6052,7 @@
       "dependencies": {
         "inherits": {
           "version": "2.0.3",
-          "resolved": "https://registry.npm.taobao.org/inherits/download/inherits-2.0.3.tgz?cache=0&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Finherits%2Fdownload%2Finherits-2.0.3.tgz",
+          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
           "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
           "dev": true
         }
@@ -6060,13 +6060,13 @@
     },
     "http-parser-js": {
       "version": "0.4.10",
-      "resolved": "https://registry.npm.taobao.org/http-parser-js/download/http-parser-js-0.4.10.tgz?cache=0&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fhttp-parser-js%2Fdownload%2Fhttp-parser-js-0.4.10.tgz",
+      "resolved": "https://registry.npmjs.org/http-parser-js/-/http-parser-js-0.4.10.tgz",
       "integrity": "sha1-ksnBN0w1CF912zWexWzCV8u5P6Q=",
       "dev": true
     },
     "http-proxy": {
       "version": "1.17.0",
-      "resolved": "https://registry.npm.taobao.org/http-proxy/download/http-proxy-1.17.0.tgz",
+      "resolved": "https://registry.npmjs.org/http-proxy/-/http-proxy-1.17.0.tgz",
       "integrity": "sha1-etOElGWPhGBeL220Q230EPTlvpo=",
       "dev": true,
       "requires": {
@@ -6077,7 +6077,7 @@
     },
     "http-proxy-middleware": {
       "version": "0.19.1",
-      "resolved": "https://registry.npm.taobao.org/http-proxy-middleware/download/http-proxy-middleware-0.19.1.tgz",
+      "resolved": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-0.19.1.tgz",
       "integrity": "sha1-GDx9xKoUeRUDBkmMIQza+WCApDo=",
       "dev": true,
       "requires": {
@@ -6089,7 +6089,7 @@
     },
     "http-signature": {
       "version": "1.2.0",
-      "resolved": "https://registry.npm.taobao.org/http-signature/download/http-signature-1.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
       "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
       "dev": true,
       "requires": {
@@ -6100,13 +6100,13 @@
     },
     "https-browserify": {
       "version": "1.0.0",
-      "resolved": "https://registry.npm.taobao.org/https-browserify/download/https-browserify-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/https-browserify/-/https-browserify-1.0.0.tgz",
       "integrity": "sha1-7AbBDgo0wPL68Zn3/X/Hj//QPHM=",
       "dev": true
     },
     "iconv-lite": {
       "version": "0.4.24",
-      "resolved": "https://registry.npm.taobao.org/iconv-lite/download/iconv-lite-0.4.24.tgz",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
       "integrity": "sha1-ICK0sl+93CHS9SSXSkdKr+czkIs=",
       "dev": true,
       "requires": {
@@ -6115,13 +6115,13 @@
     },
     "icss-replace-symbols": {
       "version": "1.1.0",
-      "resolved": "https://registry.npm.taobao.org/icss-replace-symbols/download/icss-replace-symbols-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/icss-replace-symbols/-/icss-replace-symbols-1.1.0.tgz",
       "integrity": "sha1-Bupvg2ead0njhs/h/oEq5dsiPe0=",
       "dev": true
     },
     "icss-utils": {
       "version": "2.1.0",
-      "resolved": "https://registry.npm.taobao.org/icss-utils/download/icss-utils-2.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/icss-utils/-/icss-utils-2.1.0.tgz",
       "integrity": "sha1-g/Cg7DeL8yRheLbCrZE28TWxyWI=",
       "dev": true,
       "requires": {
@@ -6130,7 +6130,7 @@
       "dependencies": {
         "postcss": {
           "version": "6.0.23",
-          "resolved": "https://registry.npm.taobao.org/postcss/download/postcss-6.0.23.tgz?cache=0&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fpostcss%2Fdownload%2Fpostcss-6.0.23.tgz",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.23.tgz",
           "integrity": "sha1-YcgswyisYOZ3ZF+XkFTrmLwOMyQ=",
           "dev": true,
           "requires": {
@@ -6141,7 +6141,7 @@
         },
         "source-map": {
           "version": "0.6.1",
-          "resolved": "https://registry.npm.taobao.org/source-map/download/source-map-0.6.1.tgz",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
           "integrity": "sha1-dHIq8y6WFOnCh6jQu95IteLxomM=",
           "dev": true
         }
@@ -6149,25 +6149,25 @@
     },
     "ieee754": {
       "version": "1.1.13",
-      "resolved": "https://registry.npm.taobao.org/ieee754/download/ieee754-1.1.13.tgz",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.13.tgz",
       "integrity": "sha1-7BaFWOlaoYH9h9N/VcMrvLZwi4Q=",
       "dev": true
     },
     "iferr": {
       "version": "0.1.5",
-      "resolved": "https://registry.npm.taobao.org/iferr/download/iferr-0.1.5.tgz",
+      "resolved": "https://registry.npmjs.org/iferr/-/iferr-0.1.5.tgz",
       "integrity": "sha1-xg7taebY/bazEEofy8ocGS3FtQE=",
       "dev": true
     },
     "ignore": {
       "version": "3.3.10",
-      "resolved": "https://registry.npm.taobao.org/ignore/download/ignore-3.3.10.tgz",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-3.3.10.tgz",
       "integrity": "sha1-Cpf7h2mG6AgcYxFg+PnziRV/AEM=",
       "dev": true
     },
     "import-cwd": {
       "version": "2.1.0",
-      "resolved": "https://registry.npm.taobao.org/import-cwd/download/import-cwd-2.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/import-cwd/-/import-cwd-2.1.0.tgz",
       "integrity": "sha1-qmzzbnInYShcs3HsZRn1PiQ1sKk=",
       "dev": true,
       "requires": {
@@ -6176,7 +6176,7 @@
     },
     "import-fresh": {
       "version": "2.0.0",
-      "resolved": "https://registry.npm.taobao.org/import-fresh/download/import-fresh-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-2.0.0.tgz",
       "integrity": "sha1-2BNVwVYS04bGH53dOSLUMEgipUY=",
       "dev": true,
       "requires": {
@@ -6186,7 +6186,7 @@
       "dependencies": {
         "caller-path": {
           "version": "2.0.0",
-          "resolved": "https://registry.npm.taobao.org/caller-path/download/caller-path-2.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/caller-path/-/caller-path-2.0.0.tgz",
           "integrity": "sha1-Ro+DBE42mrIBD6xfBs7uFbsssfQ=",
           "dev": true,
           "requires": {
@@ -6195,7 +6195,7 @@
         },
         "resolve-from": {
           "version": "3.0.0",
-          "resolved": "https://registry.npm.taobao.org/resolve-from/download/resolve-from-3.0.0.tgz?cache=0&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fresolve-from%2Fdownload%2Fresolve-from-3.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-3.0.0.tgz",
           "integrity": "sha1-six699nWiBvItuZTM17rywoYh0g=",
           "dev": true
         }
@@ -6203,7 +6203,7 @@
     },
     "import-from": {
       "version": "2.1.0",
-      "resolved": "https://registry.npm.taobao.org/import-from/download/import-from-2.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/import-from/-/import-from-2.1.0.tgz",
       "integrity": "sha1-M1238qev/VOqpHHUuAId7ja387E=",
       "dev": true,
       "requires": {
@@ -6212,7 +6212,7 @@
       "dependencies": {
         "resolve-from": {
           "version": "3.0.0",
-          "resolved": "https://registry.npm.taobao.org/resolve-from/download/resolve-from-3.0.0.tgz?cache=0&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fresolve-from%2Fdownload%2Fresolve-from-3.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-3.0.0.tgz",
           "integrity": "sha1-six699nWiBvItuZTM17rywoYh0g=",
           "dev": true
         }
@@ -6220,7 +6220,7 @@
     },
     "import-local": {
       "version": "2.0.0",
-      "resolved": "https://registry.npm.taobao.org/import-local/download/import-local-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/import-local/-/import-local-2.0.0.tgz",
       "integrity": "sha1-VQcL44pZk88Y72236WH1vuXFoJ0=",
       "dev": true,
       "requires": {
@@ -6230,25 +6230,25 @@
     },
     "imurmurhash": {
       "version": "0.1.4",
-      "resolved": "https://registry.npm.taobao.org/imurmurhash/download/imurmurhash-0.1.4.tgz",
+      "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
       "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
       "dev": true
     },
     "indexes-of": {
       "version": "1.0.1",
-      "resolved": "https://registry.npm.taobao.org/indexes-of/download/indexes-of-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/indexes-of/-/indexes-of-1.0.1.tgz",
       "integrity": "sha1-8w9xbI4r00bHtn0985FVZqfAVgc=",
       "dev": true
     },
     "infer-owner": {
       "version": "1.0.4",
-      "resolved": "https://registry.npm.taobao.org/infer-owner/download/infer-owner-1.0.4.tgz",
+      "resolved": "https://registry.npmjs.org/infer-owner/-/infer-owner-1.0.4.tgz",
       "integrity": "sha1-xM78qo5RBRwqQLos6KPScpWvlGc=",
       "dev": true
     },
     "inflight": {
       "version": "1.0.6",
-      "resolved": "https://registry.npm.taobao.org/inflight/download/inflight-1.0.6.tgz",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
       "dev": true,
       "requires": {
@@ -6258,13 +6258,13 @@
     },
     "inherits": {
       "version": "2.0.4",
-      "resolved": "https://registry.npm.taobao.org/inherits/download/inherits-2.0.4.tgz?cache=0&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Finherits%2Fdownload%2Finherits-2.0.4.tgz",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha1-D6LGT5MpF8NDOg3tVTY6rjdBa3w=",
       "dev": true
     },
     "inquirer": {
       "version": "3.3.0",
-      "resolved": "https://registry.npm.taobao.org/inquirer/download/inquirer-3.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-3.3.0.tgz",
       "integrity": "sha1-ndLyrXZdyrH/BEO0kUQqILoifck=",
       "dev": true,
       "optional": true,
@@ -6287,14 +6287,14 @@
       "dependencies": {
         "ansi-regex": {
           "version": "3.0.0",
-          "resolved": "https://registry.npm.taobao.org/ansi-regex/download/ansi-regex-3.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
           "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
           "dev": true,
           "optional": true
         },
         "strip-ansi": {
           "version": "4.0.0",
-          "resolved": "https://registry.npm.taobao.org/strip-ansi/download/strip-ansi-4.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
           "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
           "dev": true,
           "optional": true,
@@ -6306,7 +6306,7 @@
     },
     "internal-ip": {
       "version": "4.3.0",
-      "resolved": "https://registry.npm.taobao.org/internal-ip/download/internal-ip-4.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/internal-ip/-/internal-ip-4.3.0.tgz",
       "integrity": "sha1-hFRSuq2dLKO2nGNaE3rLmg2tCQc=",
       "dev": true,
       "requires": {
@@ -6316,7 +6316,7 @@
       "dependencies": {
         "default-gateway": {
           "version": "4.2.0",
-          "resolved": "https://registry.npm.taobao.org/default-gateway/download/default-gateway-4.2.0.tgz?cache=0&sync_timestamp=1560569240081&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fdefault-gateway%2Fdownload%2Fdefault-gateway-4.2.0.tgz",
+          "resolved": "https://registry.npmjs.org/default-gateway/-/default-gateway-4.2.0.tgz",
           "integrity": "sha1-FnEEx1AMIRX23WmwpTa7jtcgVSs=",
           "dev": true,
           "requires": {
@@ -6328,7 +6328,7 @@
     },
     "invariant": {
       "version": "2.2.4",
-      "resolved": "https://registry.npm.taobao.org/invariant/download/invariant-2.2.4.tgz?cache=0&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Finvariant%2Fdownload%2Finvariant-2.2.4.tgz",
+      "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
       "integrity": "sha1-YQ88ksk1nOHbYW5TgAjSP/NRWOY=",
       "dev": true,
       "requires": {
@@ -6337,37 +6337,37 @@
     },
     "invert-kv": {
       "version": "2.0.0",
-      "resolved": "https://registry.npm.taobao.org/invert-kv/download/invert-kv-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-2.0.0.tgz",
       "integrity": "sha1-c5P1r6Weyf9fZ6J2INEcIm4+7AI=",
       "dev": true
     },
     "ip": {
       "version": "1.1.5",
-      "resolved": "https://registry.npm.taobao.org/ip/download/ip-1.1.5.tgz",
+      "resolved": "https://registry.npmjs.org/ip/-/ip-1.1.5.tgz",
       "integrity": "sha1-vd7XARQpCCjAoDnnLvJfWq7ENUo=",
       "dev": true
     },
     "ip-regex": {
       "version": "2.1.0",
-      "resolved": "https://registry.npm.taobao.org/ip-regex/download/ip-regex-2.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/ip-regex/-/ip-regex-2.1.0.tgz",
       "integrity": "sha1-+ni/XS5pE8kRzp+BnuUUa7bYROk=",
       "dev": true
     },
     "ipaddr.js": {
       "version": "1.9.0",
-      "resolved": "https://registry.npm.taobao.org/ipaddr.js/download/ipaddr.js-1.9.0.tgz",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.0.tgz",
       "integrity": "sha1-N9905DCg5HVQ/lSi3v4w2KzZX2U=",
       "dev": true
     },
     "is-absolute-url": {
       "version": "2.1.0",
-      "resolved": "https://registry.npm.taobao.org/is-absolute-url/download/is-absolute-url-2.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/is-absolute-url/-/is-absolute-url-2.1.0.tgz",
       "integrity": "sha1-UFMN+4T8yap9vnhS6Do3uTufKqY=",
       "dev": true
     },
     "is-accessor-descriptor": {
       "version": "0.1.6",
-      "resolved": "https://registry.npm.taobao.org/is-accessor-descriptor/download/is-accessor-descriptor-0.1.6.tgz",
+      "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
       "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
       "dev": true,
       "requires": {
@@ -6376,7 +6376,7 @@
       "dependencies": {
         "kind-of": {
           "version": "3.2.2",
-          "resolved": "https://registry.npm.taobao.org/kind-of/download/kind-of-3.2.2.tgz",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
           "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
           "dev": true,
           "requires": {
@@ -6387,13 +6387,13 @@
     },
     "is-arrayish": {
       "version": "0.2.1",
-      "resolved": "https://registry.npm.taobao.org/is-arrayish/download/is-arrayish-0.2.1.tgz",
+      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
       "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=",
       "dev": true
     },
     "is-binary-path": {
       "version": "1.0.1",
-      "resolved": "https://registry.npm.taobao.org/is-binary-path/download/is-binary-path-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-1.0.1.tgz",
       "integrity": "sha1-dfFmQrSA8YenEcgUFh/TpKdlWJg=",
       "dev": true,
       "requires": {
@@ -6402,19 +6402,19 @@
     },
     "is-buffer": {
       "version": "1.1.6",
-      "resolved": "https://registry.npm.taobao.org/is-buffer/download/is-buffer-1.1.6.tgz",
+      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
       "integrity": "sha1-76ouqdqg16suoTqXsritUf776L4=",
       "dev": true
     },
     "is-callable": {
       "version": "1.1.4",
-      "resolved": "https://registry.npm.taobao.org/is-callable/download/is-callable-1.1.4.tgz",
+      "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.1.4.tgz",
       "integrity": "sha1-HhrfIZ4e62hNaR+dagX/DTCiTXU=",
       "dev": true
     },
     "is-ci": {
       "version": "1.2.1",
-      "resolved": "https://registry.npm.taobao.org/is-ci/download/is-ci-1.2.1.tgz",
+      "resolved": "https://registry.npmjs.org/is-ci/-/is-ci-1.2.1.tgz",
       "integrity": "sha1-43ecjuF/zPQoSI9uKBGH8uYyhBw=",
       "dev": true,
       "requires": {
@@ -6423,7 +6423,7 @@
     },
     "is-color-stop": {
       "version": "1.1.0",
-      "resolved": "https://registry.npm.taobao.org/is-color-stop/download/is-color-stop-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/is-color-stop/-/is-color-stop-1.1.0.tgz",
       "integrity": "sha1-z/9HGu5N1cnhWFmPvhKWe1za00U=",
       "dev": true,
       "requires": {
@@ -6437,7 +6437,7 @@
     },
     "is-data-descriptor": {
       "version": "0.1.4",
-      "resolved": "https://registry.npm.taobao.org/is-data-descriptor/download/is-data-descriptor-0.1.4.tgz",
+      "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
       "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
       "dev": true,
       "requires": {
@@ -6446,7 +6446,7 @@
       "dependencies": {
         "kind-of": {
           "version": "3.2.2",
-          "resolved": "https://registry.npm.taobao.org/kind-of/download/kind-of-3.2.2.tgz",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
           "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
           "dev": true,
           "requires": {
@@ -6457,13 +6457,13 @@
     },
     "is-date-object": {
       "version": "1.0.1",
-      "resolved": "https://registry.npm.taobao.org/is-date-object/download/is-date-object-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.1.tgz",
       "integrity": "sha1-mqIOtq7rv/d/vTPnTKAbM1gdOhY=",
       "dev": true
     },
     "is-descriptor": {
       "version": "0.1.6",
-      "resolved": "https://registry.npm.taobao.org/is-descriptor/download/is-descriptor-0.1.6.tgz",
+      "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
       "integrity": "sha1-Nm2CQN3kh8pRgjsaufB6EKeCUco=",
       "dev": true,
       "requires": {
@@ -6474,7 +6474,7 @@
       "dependencies": {
         "kind-of": {
           "version": "5.1.0",
-          "resolved": "https://registry.npm.taobao.org/kind-of/download/kind-of-5.1.0.tgz",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
           "integrity": "sha1-cpyR4thXt6QZofmqZWhcTDP1hF0=",
           "dev": true
         }
@@ -6482,31 +6482,31 @@
     },
     "is-directory": {
       "version": "0.3.1",
-      "resolved": "https://registry.npm.taobao.org/is-directory/download/is-directory-0.3.1.tgz",
+      "resolved": "https://registry.npmjs.org/is-directory/-/is-directory-0.3.1.tgz",
       "integrity": "sha1-YTObbyR1/Hcv2cnYP1yFddwVSuE=",
       "dev": true
     },
     "is-extendable": {
       "version": "0.1.1",
-      "resolved": "https://registry.npm.taobao.org/is-extendable/download/is-extendable-0.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
       "integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik=",
       "dev": true
     },
     "is-extglob": {
       "version": "2.1.1",
-      "resolved": "https://registry.npm.taobao.org/is-extglob/download/is-extglob-2.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
       "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
       "dev": true
     },
     "is-fullwidth-code-point": {
       "version": "2.0.0",
-      "resolved": "https://registry.npm.taobao.org/is-fullwidth-code-point/download/is-fullwidth-code-point-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
       "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
       "dev": true
     },
     "is-glob": {
       "version": "4.0.1",
-      "resolved": "https://registry.npm.taobao.org/is-glob/download/is-glob-4.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.1.tgz",
       "integrity": "sha1-dWfb6fL14kZ7x3q4PEopSCQHpdw=",
       "dev": true,
       "requires": {
@@ -6515,7 +6515,7 @@
     },
     "is-number": {
       "version": "3.0.0",
-      "resolved": "https://registry.npm.taobao.org/is-number/download/is-number-3.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
       "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
       "dev": true,
       "requires": {
@@ -6524,7 +6524,7 @@
       "dependencies": {
         "kind-of": {
           "version": "3.2.2",
-          "resolved": "https://registry.npm.taobao.org/kind-of/download/kind-of-3.2.2.tgz",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
           "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
           "dev": true,
           "requires": {
@@ -6535,19 +6535,19 @@
     },
     "is-obj": {
       "version": "1.0.1",
-      "resolved": "https://registry.npm.taobao.org/is-obj/download/is-obj-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
       "integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8=",
       "dev": true
     },
     "is-path-cwd": {
       "version": "2.2.0",
-      "resolved": "https://registry.npm.taobao.org/is-path-cwd/download/is-path-cwd-2.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/is-path-cwd/-/is-path-cwd-2.2.0.tgz",
       "integrity": "sha1-Z9Q7gmZKe1GR/ZEZEn6zAASKn9s=",
       "dev": true
     },
     "is-path-in-cwd": {
       "version": "2.1.0",
-      "resolved": "https://registry.npm.taobao.org/is-path-in-cwd/download/is-path-in-cwd-2.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/is-path-in-cwd/-/is-path-in-cwd-2.1.0.tgz",
       "integrity": "sha1-v+Lcomxp85cmWkAJljYCk1oFOss=",
       "dev": true,
       "requires": {
@@ -6556,7 +6556,7 @@
     },
     "is-path-inside": {
       "version": "2.1.0",
-      "resolved": "https://registry.npm.taobao.org/is-path-inside/download/is-path-inside-2.1.0.tgz?cache=0&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fis-path-inside%2Fdownload%2Fis-path-inside-2.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-2.1.0.tgz",
       "integrity": "sha1-fJgQWH1lmkDSe8201WFuqwWUlLI=",
       "dev": true,
       "requires": {
@@ -6565,13 +6565,13 @@
     },
     "is-plain-obj": {
       "version": "1.1.0",
-      "resolved": "https://registry.npm.taobao.org/is-plain-obj/download/is-plain-obj-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
       "integrity": "sha1-caUMhCnfync8kqOQpKA7OfzVHT4=",
       "dev": true
     },
     "is-plain-object": {
       "version": "2.0.4",
-      "resolved": "https://registry.npm.taobao.org/is-plain-object/download/is-plain-object-2.0.4.tgz?cache=0&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fis-plain-object%2Fdownload%2Fis-plain-object-2.0.4.tgz",
+      "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
       "integrity": "sha1-LBY7P6+xtgbZ0Xko8FwqHDjgdnc=",
       "dev": true,
       "requires": {
@@ -6580,13 +6580,13 @@
     },
     "is-promise": {
       "version": "2.1.0",
-      "resolved": "https://registry.npm.taobao.org/is-promise/download/is-promise-2.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-2.1.0.tgz",
       "integrity": "sha1-eaKp7OfwlugPNtKy87wWwf9L8/o=",
       "dev": true
     },
     "is-regex": {
       "version": "1.0.4",
-      "resolved": "https://registry.npm.taobao.org/is-regex/download/is-regex-1.0.4.tgz",
+      "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.4.tgz",
       "integrity": "sha1-VRdIm1RwkbCTDglWVM7SXul+lJE=",
       "dev": true,
       "requires": {
@@ -6595,19 +6595,19 @@
     },
     "is-resolvable": {
       "version": "1.1.0",
-      "resolved": "https://registry.npm.taobao.org/is-resolvable/download/is-resolvable-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/is-resolvable/-/is-resolvable-1.1.0.tgz",
       "integrity": "sha1-+xj4fOH+uSUWnJpAfBkxijIG7Yg=",
       "dev": true
     },
     "is-stream": {
       "version": "1.1.0",
-      "resolved": "https://registry.npm.taobao.org/is-stream/download/is-stream-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
       "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
       "dev": true
     },
     "is-svg": {
       "version": "3.0.0",
-      "resolved": "https://registry.npm.taobao.org/is-svg/download/is-svg-3.0.0.tgz?cache=0&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fis-svg%2Fdownload%2Fis-svg-3.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/is-svg/-/is-svg-3.0.0.tgz",
       "integrity": "sha1-kyHb0pwhLlypnE+peUxxS8r6L3U=",
       "dev": true,
       "requires": {
@@ -6616,7 +6616,7 @@
     },
     "is-symbol": {
       "version": "1.0.2",
-      "resolved": "https://registry.npm.taobao.org/is-symbol/download/is-symbol-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.2.tgz",
       "integrity": "sha1-oFX2rlcZLK7jKeeoYBGLSXqVDzg=",
       "dev": true,
       "requires": {
@@ -6625,67 +6625,67 @@
     },
     "is-typedarray": {
       "version": "1.0.0",
-      "resolved": "https://registry.npm.taobao.org/is-typedarray/download/is-typedarray-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
       "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
       "dev": true
     },
     "is-windows": {
       "version": "1.0.2",
-      "resolved": "https://registry.npm.taobao.org/is-windows/download/is-windows-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/is-windows/-/is-windows-1.0.2.tgz",
       "integrity": "sha1-0YUOuXkezRjmGCzhKjDzlmNLsZ0=",
       "dev": true
     },
     "is-wsl": {
       "version": "1.1.0",
-      "resolved": "https://registry.npm.taobao.org/is-wsl/download/is-wsl-1.1.0.tgz?cache=0&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fis-wsl%2Fdownload%2Fis-wsl-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-1.1.0.tgz",
       "integrity": "sha1-HxbkqiKwTRM2tmGIpmrzxgDDpm0=",
       "dev": true
     },
     "isarray": {
       "version": "1.0.0",
-      "resolved": "https://registry.npm.taobao.org/isarray/download/isarray-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
       "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
       "dev": true
     },
     "isexe": {
       "version": "2.0.0",
-      "resolved": "https://registry.npm.taobao.org/isexe/download/isexe-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
       "dev": true
     },
     "isobject": {
       "version": "3.0.1",
-      "resolved": "https://registry.npm.taobao.org/isobject/download/isobject-3.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
       "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
       "dev": true
     },
     "isstream": {
       "version": "0.1.2",
-      "resolved": "https://registry.npm.taobao.org/isstream/download/isstream-0.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
       "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
       "dev": true
     },
     "javascript-stringify": {
       "version": "1.6.0",
-      "resolved": "https://registry.npm.taobao.org/javascript-stringify/download/javascript-stringify-1.6.0.tgz",
+      "resolved": "https://registry.npmjs.org/javascript-stringify/-/javascript-stringify-1.6.0.tgz",
       "integrity": "sha1-FC0RHzpuPa6PSpr9d9RYVbWpzOM=",
       "dev": true
     },
     "js-levenshtein": {
       "version": "1.1.6",
-      "resolved": "https://registry.npm.taobao.org/js-levenshtein/download/js-levenshtein-1.1.6.tgz",
+      "resolved": "https://registry.npmjs.org/js-levenshtein/-/js-levenshtein-1.1.6.tgz",
       "integrity": "sha1-xs7ljrNVA3LfjeuF+tXOZs4B1Z0=",
       "dev": true
     },
     "js-message": {
       "version": "1.0.5",
-      "resolved": "https://registry.npm.taobao.org/js-message/download/js-message-1.0.5.tgz",
+      "resolved": "https://registry.npmjs.org/js-message/-/js-message-1.0.5.tgz",
       "integrity": "sha1-IwDSSxrwjondCVvBpMnJz8uJLRU=",
       "dev": true
     },
     "js-queue": {
       "version": "2.0.0",
-      "resolved": "https://registry.npm.taobao.org/js-queue/download/js-queue-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/js-queue/-/js-queue-2.0.0.tgz",
       "integrity": "sha1-NiITz4YPRo8BJfxslqvBdCUx+Ug=",
       "dev": true,
       "requires": {
@@ -6694,13 +6694,13 @@
     },
     "js-tokens": {
       "version": "4.0.0",
-      "resolved": "https://registry.npm.taobao.org/js-tokens/download/js-tokens-4.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
       "integrity": "sha1-GSA/tZmR35jjoocFDUZHzerzJJk=",
       "dev": true
     },
     "js-yaml": {
       "version": "3.13.1",
-      "resolved": "https://registry.npm.taobao.org/js-yaml/download/js-yaml-3.13.1.tgz",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.13.1.tgz",
       "integrity": "sha1-r/FRswv9+o5J4F2iLnQV6d+jeEc=",
       "dev": true,
       "requires": {
@@ -6710,55 +6710,55 @@
     },
     "jsbn": {
       "version": "0.1.1",
-      "resolved": "https://registry.npm.taobao.org/jsbn/download/jsbn-0.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
       "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
       "dev": true
     },
     "jsesc": {
       "version": "2.5.2",
-      "resolved": "https://registry.npm.taobao.org/jsesc/download/jsesc-2.5.2.tgz",
+      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
       "integrity": "sha1-gFZNLkg9rPbo7yCWUKZ98/DCg6Q=",
       "dev": true
     },
     "json-parse-better-errors": {
       "version": "1.0.2",
-      "resolved": "https://registry.npm.taobao.org/json-parse-better-errors/download/json-parse-better-errors-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
       "integrity": "sha1-u4Z8+zRQ5pEHwTHRxRS6s9yLyqk=",
       "dev": true
     },
     "json-schema": {
       "version": "0.2.3",
-      "resolved": "https://registry.npm.taobao.org/json-schema/download/json-schema-0.2.3.tgz?cache=0&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fjson-schema%2Fdownload%2Fjson-schema-0.2.3.tgz",
+      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
       "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM=",
       "dev": true
     },
     "json-schema-traverse": {
       "version": "0.4.1",
-      "resolved": "https://registry.npm.taobao.org/json-schema-traverse/download/json-schema-traverse-0.4.1.tgz",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
       "integrity": "sha1-afaofZUTq4u4/mO9sJecRI5oRmA=",
       "dev": true
     },
     "json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
-      "resolved": "https://registry.npm.taobao.org/json-stable-stringify-without-jsonify/download/json-stable-stringify-without-jsonify-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
       "integrity": "sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE=",
       "dev": true
     },
     "json-stringify-safe": {
       "version": "5.0.1",
-      "resolved": "https://registry.npm.taobao.org/json-stringify-safe/download/json-stringify-safe-5.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
       "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
       "dev": true
     },
     "json3": {
       "version": "3.3.3",
-      "resolved": "https://registry.npm.taobao.org/json3/download/json3-3.3.3.tgz",
+      "resolved": "https://registry.npmjs.org/json3/-/json3-3.3.3.tgz",
       "integrity": "sha1-f8EON1/FrkLEcFpcwKpvYr4wW4E=",
       "dev": true
     },
     "json5": {
       "version": "2.1.0",
-      "resolved": "https://registry.npm.taobao.org/json5/download/json5-2.1.0.tgz?cache=0&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fjson5%2Fdownload%2Fjson5-2.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.1.0.tgz",
       "integrity": "sha1-56DGLEgoXGKNIKELhcibuAfDKFA=",
       "dev": true,
       "requires": {
@@ -6767,7 +6767,7 @@
     },
     "jsonfile": {
       "version": "4.0.0",
-      "resolved": "https://registry.npm.taobao.org/jsonfile/download/jsonfile-4.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
       "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
       "dev": true,
       "requires": {
@@ -6776,13 +6776,13 @@
     },
     "jsonify": {
       "version": "0.0.0",
-      "resolved": "https://registry.npm.taobao.org/jsonify/download/jsonify-0.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
       "integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM=",
       "dev": true
     },
     "jsprim": {
       "version": "1.4.1",
-      "resolved": "https://registry.npm.taobao.org/jsprim/download/jsprim-1.4.1.tgz",
+      "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
       "integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
       "dev": true,
       "requires": {
@@ -6794,19 +6794,19 @@
     },
     "killable": {
       "version": "1.0.1",
-      "resolved": "https://registry.npm.taobao.org/killable/download/killable-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/killable/-/killable-1.0.1.tgz",
       "integrity": "sha1-TIzkQRh6Bhx0dPuHygjipjgZSJI=",
       "dev": true
     },
     "kind-of": {
       "version": "6.0.2",
-      "resolved": "https://registry.npm.taobao.org/kind-of/download/kind-of-6.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
       "integrity": "sha1-ARRrNqYhjmTljzqNZt5df8b20FE=",
       "dev": true
     },
     "launch-editor": {
       "version": "2.2.1",
-      "resolved": "https://registry.npm.taobao.org/launch-editor/download/launch-editor-2.2.1.tgz",
+      "resolved": "https://registry.npmjs.org/launch-editor/-/launch-editor-2.2.1.tgz",
       "integrity": "sha1-hxtaPuOdZoD8wm03kwtu7aidsMo=",
       "dev": true,
       "requires": {
@@ -6816,7 +6816,7 @@
     },
     "launch-editor-middleware": {
       "version": "2.2.1",
-      "resolved": "https://registry.npm.taobao.org/launch-editor-middleware/download/launch-editor-middleware-2.2.1.tgz",
+      "resolved": "https://registry.npmjs.org/launch-editor-middleware/-/launch-editor-middleware-2.2.1.tgz",
       "integrity": "sha1-4UsH5scVSwpLhqD9NFeE5FgEwVc=",
       "dev": true,
       "requires": {
@@ -6825,7 +6825,7 @@
     },
     "lcid": {
       "version": "2.0.0",
-      "resolved": "https://registry.npm.taobao.org/lcid/download/lcid-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/lcid/-/lcid-2.0.0.tgz",
       "integrity": "sha1-bvXS32DlL4LrIopMNz6NHzlyU88=",
       "dev": true,
       "requires": {
@@ -6834,7 +6834,7 @@
     },
     "levn": {
       "version": "0.3.0",
-      "resolved": "https://registry.npm.taobao.org/levn/download/levn-0.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
       "integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
       "dev": true,
       "requires": {
@@ -6844,13 +6844,13 @@
     },
     "lines-and-columns": {
       "version": "1.1.6",
-      "resolved": "https://registry.npm.taobao.org/lines-and-columns/download/lines-and-columns-1.1.6.tgz",
+      "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.1.6.tgz",
       "integrity": "sha1-HADHQ7QzzQpOgHWPe2SldEDZ/wA=",
       "dev": true
     },
     "loader-fs-cache": {
       "version": "1.0.2",
-      "resolved": "https://registry.npm.taobao.org/loader-fs-cache/download/loader-fs-cache-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/loader-fs-cache/-/loader-fs-cache-1.0.2.tgz",
       "integrity": "sha1-VM7fa3J+F3n9jwEgXwX26IcG8IY=",
       "dev": true,
       "requires": {
@@ -6860,7 +6860,7 @@
       "dependencies": {
         "find-cache-dir": {
           "version": "0.1.1",
-          "resolved": "https://registry.npm.taobao.org/find-cache-dir/download/find-cache-dir-0.1.1.tgz",
+          "resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-0.1.1.tgz",
           "integrity": "sha1-yN765XyKUqinhPnjHFfHQumToLk=",
           "dev": true,
           "requires": {
@@ -6871,7 +6871,7 @@
         },
         "find-up": {
           "version": "1.1.2",
-          "resolved": "https://registry.npm.taobao.org/find-up/download/find-up-1.1.2.tgz",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
           "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
           "dev": true,
           "requires": {
@@ -6881,7 +6881,7 @@
         },
         "path-exists": {
           "version": "2.1.0",
-          "resolved": "https://registry.npm.taobao.org/path-exists/download/path-exists-2.1.0.tgz",
+          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
           "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
           "dev": true,
           "requires": {
@@ -6890,7 +6890,7 @@
         },
         "pkg-dir": {
           "version": "1.0.0",
-          "resolved": "https://registry.npm.taobao.org/pkg-dir/download/pkg-dir-1.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-1.0.0.tgz",
           "integrity": "sha1-ektQio1bstYp1EcFb/TpyTFM89Q=",
           "dev": true,
           "requires": {
@@ -6901,13 +6901,13 @@
     },
     "loader-runner": {
       "version": "2.4.0",
-      "resolved": "https://registry.npm.taobao.org/loader-runner/download/loader-runner-2.4.0.tgz",
+      "resolved": "https://registry.npmjs.org/loader-runner/-/loader-runner-2.4.0.tgz",
       "integrity": "sha1-7UcGa/5TTX6ExMe5mYwqdWB9k1c=",
       "dev": true
     },
     "loader-utils": {
       "version": "1.2.3",
-      "resolved": "https://registry.npm.taobao.org/loader-utils/download/loader-utils-1.2.3.tgz",
+      "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.2.3.tgz",
       "integrity": "sha1-H/XcaRHJ8KBiUxpMBLYJQGEIwsc=",
       "dev": true,
       "requires": {
@@ -6918,7 +6918,7 @@
       "dependencies": {
         "json5": {
           "version": "1.0.1",
-          "resolved": "https://registry.npm.taobao.org/json5/download/json5-1.0.1.tgz?cache=0&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fjson5%2Fdownload%2Fjson5-1.0.1.tgz",
+          "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
           "integrity": "sha1-d5+wAYYE+oVOrL9iUhgNg1Q+Pb4=",
           "dev": true,
           "requires": {
@@ -6929,7 +6929,7 @@
     },
     "locate-path": {
       "version": "2.0.0",
-      "resolved": "https://registry.npm.taobao.org/locate-path/download/locate-path-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
       "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
       "dev": true,
       "requires": {
@@ -6939,49 +6939,49 @@
     },
     "lodash": {
       "version": "4.17.15",
-      "resolved": "https://registry.npm.taobao.org/lodash/download/lodash-4.17.15.tgz",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
       "integrity": "sha1-tEf2ZwoEVbv+7dETku/zMOoJdUg=",
       "dev": true
     },
     "lodash.defaultsdeep": {
       "version": "4.6.1",
-      "resolved": "https://registry.npm.taobao.org/lodash.defaultsdeep/download/lodash.defaultsdeep-4.6.1.tgz?cache=0&sync_timestamp=1562718717933&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Flodash.defaultsdeep%2Fdownload%2Flodash.defaultsdeep-4.6.1.tgz",
+      "resolved": "https://registry.npmjs.org/lodash.defaultsdeep/-/lodash.defaultsdeep-4.6.1.tgz",
       "integrity": "sha1-US6b1yHSctlOPTpjZT+hdRZ0HKY=",
       "dev": true
     },
     "lodash.kebabcase": {
       "version": "4.1.1",
-      "resolved": "https://registry.npm.taobao.org/lodash.kebabcase/download/lodash.kebabcase-4.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/lodash.kebabcase/-/lodash.kebabcase-4.1.1.tgz",
       "integrity": "sha1-hImxyw0p/4gZXM7KRI/21swpXDY=",
       "dev": true
     },
     "lodash.mapvalues": {
       "version": "4.6.0",
-      "resolved": "https://registry.npm.taobao.org/lodash.mapvalues/download/lodash.mapvalues-4.6.0.tgz",
+      "resolved": "https://registry.npmjs.org/lodash.mapvalues/-/lodash.mapvalues-4.6.0.tgz",
       "integrity": "sha1-G6+lAF3p3W9PJmaMMMo3IwzJaJw=",
       "dev": true
     },
     "lodash.memoize": {
       "version": "4.1.2",
-      "resolved": "https://registry.npm.taobao.org/lodash.memoize/download/lodash.memoize-4.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
       "integrity": "sha1-vMbEmkKihA7Zl/Mj6tpezRguC/4=",
       "dev": true
     },
     "lodash.transform": {
       "version": "4.6.0",
-      "resolved": "https://registry.npm.taobao.org/lodash.transform/download/lodash.transform-4.6.0.tgz",
+      "resolved": "https://registry.npmjs.org/lodash.transform/-/lodash.transform-4.6.0.tgz",
       "integrity": "sha1-EjBkIvYzJK7YSD0/ODMrX2cFR6A=",
       "dev": true
     },
     "lodash.uniq": {
       "version": "4.5.0",
-      "resolved": "https://registry.npm.taobao.org/lodash.uniq/download/lodash.uniq-4.5.0.tgz",
+      "resolved": "https://registry.npmjs.org/lodash.uniq/-/lodash.uniq-4.5.0.tgz",
       "integrity": "sha1-0CJTc662Uq3BvILklFM5qEJ1R3M=",
       "dev": true
     },
     "log-symbols": {
       "version": "2.2.0",
-      "resolved": "https://registry.npm.taobao.org/log-symbols/download/log-symbols-2.2.0.tgz?cache=0&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Flog-symbols%2Fdownload%2Flog-symbols-2.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-2.2.0.tgz",
       "integrity": "sha1-V0Dhxdbw39pK2TI7UzIQfva0xAo=",
       "dev": true,
       "requires": {
@@ -6990,13 +6990,13 @@
     },
     "loglevel": {
       "version": "1.6.3",
-      "resolved": "https://registry.npm.taobao.org/loglevel/download/loglevel-1.6.3.tgz",
+      "resolved": "https://registry.npmjs.org/loglevel/-/loglevel-1.6.3.tgz",
       "integrity": "sha1-d/LrZL5VpATJ/QStFtV8HW1rEoA=",
       "dev": true
     },
     "loose-envify": {
       "version": "1.4.0",
-      "resolved": "https://registry.npm.taobao.org/loose-envify/download/loose-envify-1.4.0.tgz",
+      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
       "integrity": "sha1-ce5R+nvkyuwaY4OffmgtgTLTDK8=",
       "dev": true,
       "requires": {
@@ -7005,13 +7005,13 @@
     },
     "lower-case": {
       "version": "1.1.4",
-      "resolved": "https://registry.npm.taobao.org/lower-case/download/lower-case-1.1.4.tgz",
+      "resolved": "https://registry.npmjs.org/lower-case/-/lower-case-1.1.4.tgz",
       "integrity": "sha1-miyr0bno4K6ZOkv31YdcOcQujqw=",
       "dev": true
     },
     "lru-cache": {
       "version": "5.1.1",
-      "resolved": "https://registry.npm.taobao.org/lru-cache/download/lru-cache-5.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
       "integrity": "sha1-HaJ+ZxAnGUdpXa9oSOhH8B2EuSA=",
       "dev": true,
       "requires": {
@@ -7020,7 +7020,7 @@
     },
     "make-dir": {
       "version": "2.1.0",
-      "resolved": "https://registry.npm.taobao.org/make-dir/download/make-dir-2.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-2.1.0.tgz",
       "integrity": "sha1-XwMQ4YuL6JjMBwCSlaMK5B6R5vU=",
       "dev": true,
       "requires": {
@@ -7030,7 +7030,7 @@
     },
     "map-age-cleaner": {
       "version": "0.1.3",
-      "resolved": "https://registry.npm.taobao.org/map-age-cleaner/download/map-age-cleaner-0.1.3.tgz",
+      "resolved": "https://registry.npmjs.org/map-age-cleaner/-/map-age-cleaner-0.1.3.tgz",
       "integrity": "sha1-fVg6cwZDTAVf5HSw9FB45uG0uSo=",
       "dev": true,
       "requires": {
@@ -7039,13 +7039,13 @@
     },
     "map-cache": {
       "version": "0.2.2",
-      "resolved": "https://registry.npm.taobao.org/map-cache/download/map-cache-0.2.2.tgz",
+      "resolved": "https://registry.npmjs.org/map-cache/-/map-cache-0.2.2.tgz",
       "integrity": "sha1-wyq9C9ZSXZsFFkW7TyasXcmKDb8=",
       "dev": true
     },
     "map-visit": {
       "version": "1.0.0",
-      "resolved": "https://registry.npm.taobao.org/map-visit/download/map-visit-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/map-visit/-/map-visit-1.0.0.tgz",
       "integrity": "sha1-7Nyo8TFE5mDxtb1B8S80edmN+48=",
       "dev": true,
       "requires": {
@@ -7054,7 +7054,7 @@
     },
     "md5.js": {
       "version": "1.3.5",
-      "resolved": "https://registry.npm.taobao.org/md5.js/download/md5.js-1.3.5.tgz",
+      "resolved": "https://registry.npmjs.org/md5.js/-/md5.js-1.3.5.tgz",
       "integrity": "sha1-tdB7jjIW4+J81yjXL3DR5qNCAF8=",
       "dev": true,
       "requires": {
@@ -7065,19 +7065,19 @@
     },
     "mdn-data": {
       "version": "2.0.4",
-      "resolved": "https://registry.npm.taobao.org/mdn-data/download/mdn-data-2.0.4.tgz",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.0.4.tgz",
       "integrity": "sha1-aZs8OKxvHXKAkaZGULZdOIUC/Vs=",
       "dev": true
     },
     "media-typer": {
       "version": "0.3.0",
-      "resolved": "https://registry.npm.taobao.org/media-typer/download/media-typer-0.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
       "integrity": "sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g=",
       "dev": true
     },
     "mem": {
       "version": "4.3.0",
-      "resolved": "https://registry.npm.taobao.org/mem/download/mem-4.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/mem/-/mem-4.3.0.tgz",
       "integrity": "sha1-Rhr0l7xK4JYIzbLmDu+2m/90QXg=",
       "dev": true,
       "requires": {
@@ -7088,7 +7088,7 @@
       "dependencies": {
         "mimic-fn": {
           "version": "2.1.0",
-          "resolved": "https://registry.npm.taobao.org/mimic-fn/download/mimic-fn-2.1.0.tgz",
+          "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
           "integrity": "sha1-ftLCzMyvhNP/y3pptXcR/CCDQBs=",
           "dev": true
         }
@@ -7096,7 +7096,7 @@
     },
     "memory-fs": {
       "version": "0.4.1",
-      "resolved": "https://registry.npm.taobao.org/memory-fs/download/memory-fs-0.4.1.tgz",
+      "resolved": "https://registry.npmjs.org/memory-fs/-/memory-fs-0.4.1.tgz",
       "integrity": "sha1-OpoguEYlI+RHz7x+i7gO1me/xVI=",
       "dev": true,
       "requires": {
@@ -7106,13 +7106,13 @@
     },
     "merge-descriptors": {
       "version": "1.0.1",
-      "resolved": "https://registry.npm.taobao.org/merge-descriptors/download/merge-descriptors-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
       "integrity": "sha1-sAqqVW3YtEVoFQ7J0blT8/kMu2E=",
       "dev": true
     },
     "merge-source-map": {
       "version": "1.1.0",
-      "resolved": "https://registry.npm.taobao.org/merge-source-map/download/merge-source-map-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/merge-source-map/-/merge-source-map-1.1.0.tgz",
       "integrity": "sha1-L93n5gIJOfcJBqaPLXrmheTIxkY=",
       "dev": true,
       "requires": {
@@ -7121,7 +7121,7 @@
       "dependencies": {
         "source-map": {
           "version": "0.6.1",
-          "resolved": "https://registry.npm.taobao.org/source-map/download/source-map-0.6.1.tgz",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
           "integrity": "sha1-dHIq8y6WFOnCh6jQu95IteLxomM=",
           "dev": true
         }
@@ -7129,19 +7129,19 @@
     },
     "merge2": {
       "version": "1.2.4",
-      "resolved": "https://registry.npm.taobao.org/merge2/download/merge2-1.2.4.tgz?cache=0&sync_timestamp=1564568903369&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fmerge2%2Fdownload%2Fmerge2-1.2.4.tgz",
+      "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.2.4.tgz",
       "integrity": "sha1-ySaVieaIWmDPgGBdlSLUtnymRuM=",
       "dev": true
     },
     "methods": {
       "version": "1.1.2",
-      "resolved": "https://registry.npm.taobao.org/methods/download/methods-1.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
       "integrity": "sha1-VSmk1nZUE07cxSZmVoNbD4Ua/O4=",
       "dev": true
     },
     "micromatch": {
       "version": "3.1.10",
-      "resolved": "https://registry.npm.taobao.org/micromatch/download/micromatch-3.1.10.tgz",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
       "integrity": "sha1-cIWbyVyYQJUvNZoGij/En57PrCM=",
       "dev": true,
       "requires": {
@@ -7162,7 +7162,7 @@
     },
     "miller-rabin": {
       "version": "4.0.1",
-      "resolved": "https://registry.npm.taobao.org/miller-rabin/download/miller-rabin-4.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/miller-rabin/-/miller-rabin-4.0.1.tgz",
       "integrity": "sha1-8IA1HIZbDcViqEYpZtqlNUPHik0=",
       "dev": true,
       "requires": {
@@ -7172,19 +7172,19 @@
     },
     "mime": {
       "version": "2.4.4",
-      "resolved": "https://registry.npm.taobao.org/mime/download/mime-2.4.4.tgz",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-2.4.4.tgz",
       "integrity": "sha1-vXuRE1/GsBzePpuuM9ZZtj2IV+U=",
       "dev": true
     },
     "mime-db": {
       "version": "1.40.0",
-      "resolved": "https://registry.npm.taobao.org/mime-db/download/mime-db-1.40.0.tgz",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.40.0.tgz",
       "integrity": "sha1-plBX6ZjbCQ9zKmj2wnbTh9QSbDI=",
       "dev": true
     },
     "mime-types": {
       "version": "2.1.24",
-      "resolved": "https://registry.npm.taobao.org/mime-types/download/mime-types-2.1.24.tgz",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.24.tgz",
       "integrity": "sha1-tvjQs+lR77d97eyhlM/20W9nb4E=",
       "dev": true,
       "requires": {
@@ -7193,13 +7193,13 @@
     },
     "mimic-fn": {
       "version": "1.2.0",
-      "resolved": "https://registry.npm.taobao.org/mimic-fn/download/mimic-fn-1.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.2.0.tgz",
       "integrity": "sha1-ggyGo5M0ZA6ZUWkovQP8qIBX0CI=",
       "dev": true
     },
     "mini-css-extract-plugin": {
       "version": "0.6.0",
-      "resolved": "https://registry.npm.taobao.org/mini-css-extract-plugin/download/mini-css-extract-plugin-0.6.0.tgz",
+      "resolved": "https://registry.npmjs.org/mini-css-extract-plugin/-/mini-css-extract-plugin-0.6.0.tgz",
       "integrity": "sha1-o/Ezctb83pEvPuTNA5ZlcEgB47k=",
       "dev": true,
       "requires": {
@@ -7211,7 +7211,7 @@
       "dependencies": {
         "normalize-url": {
           "version": "2.0.1",
-          "resolved": "https://registry.npm.taobao.org/normalize-url/download/normalize-url-2.0.1.tgz?cache=0&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fnormalize-url%2Fdownload%2Fnormalize-url-2.0.1.tgz",
+          "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-2.0.1.tgz",
           "integrity": "sha1-g1qdoVUfom9w6SMpBpojqmV01+Y=",
           "dev": true,
           "requires": {
@@ -7222,7 +7222,7 @@
         },
         "schema-utils": {
           "version": "1.0.0",
-          "resolved": "https://registry.npm.taobao.org/schema-utils/download/schema-utils-1.0.0.tgz?cache=0&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fschema-utils%2Fdownload%2Fschema-utils-1.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-1.0.0.tgz",
           "integrity": "sha1-C3mpMgTXtgDUsoUNH2bCo0lRx3A=",
           "dev": true,
           "requires": {
@@ -7235,19 +7235,19 @@
     },
     "minimalistic-assert": {
       "version": "1.0.1",
-      "resolved": "https://registry.npm.taobao.org/minimalistic-assert/download/minimalistic-assert-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
       "integrity": "sha1-LhlN4ERibUoQ5/f7wAznPoPk1cc=",
       "dev": true
     },
     "minimalistic-crypto-utils": {
       "version": "1.0.1",
-      "resolved": "https://registry.npm.taobao.org/minimalistic-crypto-utils/download/minimalistic-crypto-utils-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/minimalistic-crypto-utils/-/minimalistic-crypto-utils-1.0.1.tgz",
       "integrity": "sha1-9sAMHAsIIkblxNmd+4x8CDsrWCo=",
       "dev": true
     },
     "minimatch": {
       "version": "3.0.4",
-      "resolved": "https://registry.npm.taobao.org/minimatch/download/minimatch-3.0.4.tgz?cache=0&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fminimatch%2Fdownload%2Fminimatch-3.0.4.tgz",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
       "integrity": "sha1-UWbihkV/AzBgZL5Ul+jbsMPTIIM=",
       "dev": true,
       "requires": {
@@ -7256,13 +7256,13 @@
     },
     "minimist": {
       "version": "1.2.0",
-      "resolved": "https://registry.npm.taobao.org/minimist/download/minimist-1.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
       "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
       "dev": true
     },
     "mississippi": {
       "version": "3.0.0",
-      "resolved": "https://registry.npm.taobao.org/mississippi/download/mississippi-3.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/mississippi/-/mississippi-3.0.0.tgz",
       "integrity": "sha1-6goykfl+C16HdrNj1fChLZTGcCI=",
       "dev": true,
       "requires": {
@@ -7280,7 +7280,7 @@
     },
     "mixin-deep": {
       "version": "1.3.2",
-      "resolved": "https://registry.npm.taobao.org/mixin-deep/download/mixin-deep-1.3.2.tgz?cache=0&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fmixin-deep%2Fdownload%2Fmixin-deep-1.3.2.tgz",
+      "resolved": "https://registry.npmjs.org/mixin-deep/-/mixin-deep-1.3.2.tgz",
       "integrity": "sha1-ESC0PcNZp4Xc5ltVuC4lfM9HlWY=",
       "dev": true,
       "requires": {
@@ -7290,7 +7290,7 @@
       "dependencies": {
         "is-extendable": {
           "version": "1.0.1",
-          "resolved": "https://registry.npm.taobao.org/is-extendable/download/is-extendable-1.0.1.tgz",
+          "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
           "integrity": "sha1-p0cPnkJnM9gb2B4RVSZOOjUHyrQ=",
           "dev": true,
           "requires": {
@@ -7301,7 +7301,7 @@
     },
     "mkdirp": {
       "version": "0.5.1",
-      "resolved": "https://registry.npm.taobao.org/mkdirp/download/mkdirp-0.5.1.tgz?cache=0&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fmkdirp%2Fdownload%2Fmkdirp-0.5.1.tgz",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
       "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
       "dev": true,
       "requires": {
@@ -7310,7 +7310,7 @@
       "dependencies": {
         "minimist": {
           "version": "0.0.8",
-          "resolved": "https://registry.npm.taobao.org/minimist/download/minimist-0.0.8.tgz",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
           "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
           "dev": true
         }
@@ -7318,7 +7318,7 @@
     },
     "move-concurrently": {
       "version": "1.0.1",
-      "resolved": "https://registry.npm.taobao.org/move-concurrently/download/move-concurrently-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/move-concurrently/-/move-concurrently-1.0.1.tgz",
       "integrity": "sha1-viwAX9oy4LKa8fBdfEszIUxwH5I=",
       "dev": true,
       "requires": {
@@ -7332,13 +7332,13 @@
     },
     "ms": {
       "version": "2.1.2",
-      "resolved": "https://registry.npm.taobao.org/ms/download/ms-2.1.2.tgz?cache=0&sync_timestamp=1559842528856&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fms%2Fdownload%2Fms-2.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
       "integrity": "sha1-0J0fNXtEP0kzgqjrPM0YOHKuYAk=",
       "dev": true
     },
     "multicast-dns": {
       "version": "6.2.3",
-      "resolved": "https://registry.npm.taobao.org/multicast-dns/download/multicast-dns-6.2.3.tgz",
+      "resolved": "https://registry.npmjs.org/multicast-dns/-/multicast-dns-6.2.3.tgz",
       "integrity": "sha1-oOx72QVcQoL3kMPIL04o2zsxsik=",
       "dev": true,
       "requires": {
@@ -7348,19 +7348,19 @@
     },
     "multicast-dns-service-types": {
       "version": "1.1.0",
-      "resolved": "https://registry.npm.taobao.org/multicast-dns-service-types/download/multicast-dns-service-types-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/multicast-dns-service-types/-/multicast-dns-service-types-1.1.0.tgz",
       "integrity": "sha1-iZ8R2WhuXgXLkbNdXw5jt3PPyQE=",
       "dev": true
     },
     "mute-stream": {
       "version": "0.0.7",
-      "resolved": "https://registry.npm.taobao.org/mute-stream/download/mute-stream-0.0.7.tgz",
+      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.7.tgz",
       "integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s=",
       "dev": true
     },
     "mz": {
       "version": "2.7.0",
-      "resolved": "https://registry.npm.taobao.org/mz/download/mz-2.7.0.tgz",
+      "resolved": "https://registry.npmjs.org/mz/-/mz-2.7.0.tgz",
       "integrity": "sha1-lQCAV6Vsr63CvGPd5/n/aVWUjjI=",
       "dev": true,
       "requires": {
@@ -7371,14 +7371,14 @@
     },
     "nan": {
       "version": "2.14.0",
-      "resolved": "https://registry.npm.taobao.org/nan/download/nan-2.14.0.tgz",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.0.tgz",
       "integrity": "sha1-eBj3IgJ7JFmobwKV1DTR/CM2xSw=",
       "dev": true,
       "optional": true
     },
     "nanomatch": {
       "version": "1.2.13",
-      "resolved": "https://registry.npm.taobao.org/nanomatch/download/nanomatch-1.2.13.tgz",
+      "resolved": "https://registry.npmjs.org/nanomatch/-/nanomatch-1.2.13.tgz",
       "integrity": "sha1-uHqKpPwN6P5r6IiVs4mD/yZb0Rk=",
       "dev": true,
       "requires": {
@@ -7397,31 +7397,31 @@
     },
     "natural-compare": {
       "version": "1.4.0",
-      "resolved": "https://registry.npm.taobao.org/natural-compare/download/natural-compare-1.4.0.tgz",
+      "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
       "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
       "dev": true
     },
     "negotiator": {
       "version": "0.6.2",
-      "resolved": "https://registry.npm.taobao.org/negotiator/download/negotiator-0.6.2.tgz",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.2.tgz",
       "integrity": "sha1-/qz3zPUlp3rpY0Q2pkiD/+yjRvs=",
       "dev": true
     },
     "neo-async": {
       "version": "2.6.1",
-      "resolved": "https://registry.npm.taobao.org/neo-async/download/neo-async-2.6.1.tgz",
+      "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.1.tgz",
       "integrity": "sha1-rCetpmFn+ohJpq3dg39rGJrSCBw=",
       "dev": true
     },
     "nice-try": {
       "version": "1.0.5",
-      "resolved": "https://registry.npm.taobao.org/nice-try/download/nice-try-1.0.5.tgz",
+      "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
       "integrity": "sha1-ozeKdpbOfSI+iPybdkvX7xCJ42Y=",
       "dev": true
     },
     "no-case": {
       "version": "2.3.2",
-      "resolved": "https://registry.npm.taobao.org/no-case/download/no-case-2.3.2.tgz",
+      "resolved": "https://registry.npmjs.org/no-case/-/no-case-2.3.2.tgz",
       "integrity": "sha1-YLgTOWvjmz8SiKTB7V0efSi0ZKw=",
       "dev": true,
       "requires": {
@@ -7430,13 +7430,13 @@
     },
     "node-forge": {
       "version": "0.7.5",
-      "resolved": "https://registry.npm.taobao.org/node-forge/download/node-forge-0.7.5.tgz",
+      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.7.5.tgz",
       "integrity": "sha1-bBUsNFzhHFL0ZcKr2VfoY5zWdN8=",
       "dev": true
     },
     "node-ipc": {
       "version": "9.1.1",
-      "resolved": "https://registry.npm.taobao.org/node-ipc/download/node-ipc-9.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/node-ipc/-/node-ipc-9.1.1.tgz",
       "integrity": "sha1-TiRe1pOOZRAOWV68XcNLFujdXWk=",
       "dev": true,
       "requires": {
@@ -7447,7 +7447,7 @@
     },
     "node-libs-browser": {
       "version": "2.2.1",
-      "resolved": "https://registry.npm.taobao.org/node-libs-browser/download/node-libs-browser-2.2.1.tgz",
+      "resolved": "https://registry.npmjs.org/node-libs-browser/-/node-libs-browser-2.2.1.tgz",
       "integrity": "sha1-tk9RPRgzhiX5A0bSew0jXmMfZCU=",
       "dev": true,
       "requires": {
@@ -7478,7 +7478,7 @@
       "dependencies": {
         "punycode": {
           "version": "1.4.1",
-          "resolved": "https://registry.npm.taobao.org/punycode/download/punycode-1.4.1.tgz",
+          "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
           "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4=",
           "dev": true
         }
@@ -7486,7 +7486,7 @@
     },
     "node-releases": {
       "version": "1.1.26",
-      "resolved": "https://registry.npm.taobao.org/node-releases/download/node-releases-1.1.26.tgz",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.26.tgz",
       "integrity": "sha1-8wVj7cXH3CDPUkzIZS/6e+B2KTc=",
       "dev": true,
       "requires": {
@@ -7495,7 +7495,7 @@
     },
     "normalize-package-data": {
       "version": "2.5.0",
-      "resolved": "https://registry.npm.taobao.org/normalize-package-data/download/normalize-package-data-2.5.0.tgz",
+      "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.5.0.tgz",
       "integrity": "sha1-5m2xg4sgDB38IzIl0SyzZSDiNKg=",
       "dev": true,
       "requires": {
@@ -7507,25 +7507,25 @@
     },
     "normalize-path": {
       "version": "3.0.0",
-      "resolved": "https://registry.npm.taobao.org/normalize-path/download/normalize-path-3.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
       "integrity": "sha1-Dc1p/yOhybEf0JeDFmRKA4ghamU=",
       "dev": true
     },
     "normalize-range": {
       "version": "0.1.2",
-      "resolved": "https://registry.npm.taobao.org/normalize-range/download/normalize-range-0.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/normalize-range/-/normalize-range-0.1.2.tgz",
       "integrity": "sha1-LRDAa9/TEuqXd2laTShDlFa3WUI=",
       "dev": true
     },
     "normalize-url": {
       "version": "3.3.0",
-      "resolved": "https://registry.npm.taobao.org/normalize-url/download/normalize-url-3.3.0.tgz?cache=0&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fnormalize-url%2Fdownload%2Fnormalize-url-3.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-3.3.0.tgz",
       "integrity": "sha1-suHE3E98bVd0PfczpPWXjRhlBVk=",
       "dev": true
     },
     "npm-run-path": {
       "version": "2.0.2",
-      "resolved": "https://registry.npm.taobao.org/npm-run-path/download/npm-run-path-2.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
       "integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
       "dev": true,
       "requires": {
@@ -7534,7 +7534,7 @@
     },
     "nth-check": {
       "version": "1.0.2",
-      "resolved": "https://registry.npm.taobao.org/nth-check/download/nth-check-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-1.0.2.tgz",
       "integrity": "sha1-sr0pXDfj3VijvwcAN2Zjuk2c8Fw=",
       "dev": true,
       "requires": {
@@ -7543,31 +7543,31 @@
     },
     "num2fraction": {
       "version": "1.2.2",
-      "resolved": "https://registry.npm.taobao.org/num2fraction/download/num2fraction-1.2.2.tgz",
+      "resolved": "https://registry.npmjs.org/num2fraction/-/num2fraction-1.2.2.tgz",
       "integrity": "sha1-b2gragJ6Tp3fpFZM0lidHU5mnt4=",
       "dev": true
     },
     "number-is-nan": {
       "version": "1.0.1",
-      "resolved": "https://registry.npm.taobao.org/number-is-nan/download/number-is-nan-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
       "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
       "dev": true
     },
     "oauth-sign": {
       "version": "0.9.0",
-      "resolved": "https://registry.npm.taobao.org/oauth-sign/download/oauth-sign-0.9.0.tgz",
+      "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",
       "integrity": "sha1-R6ewFrqmi1+g7PPe4IqFxnmsZFU=",
       "dev": true
     },
     "object-assign": {
       "version": "4.1.1",
-      "resolved": "https://registry.npm.taobao.org/object-assign/download/object-assign-4.1.1.tgz?cache=0&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fobject-assign%2Fdownload%2Fobject-assign-4.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
       "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
       "dev": true
     },
     "object-copy": {
       "version": "0.1.0",
-      "resolved": "https://registry.npm.taobao.org/object-copy/download/object-copy-0.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/object-copy/-/object-copy-0.1.0.tgz",
       "integrity": "sha1-fn2Fi3gb18mRpBupde04EnVOmYw=",
       "dev": true,
       "requires": {
@@ -7578,7 +7578,7 @@
       "dependencies": {
         "define-property": {
           "version": "0.2.5",
-          "resolved": "https://registry.npm.taobao.org/define-property/download/define-property-0.2.5.tgz",
+          "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
           "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
           "dev": true,
           "requires": {
@@ -7587,7 +7587,7 @@
         },
         "kind-of": {
           "version": "3.2.2",
-          "resolved": "https://registry.npm.taobao.org/kind-of/download/kind-of-3.2.2.tgz",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
           "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
           "dev": true,
           "requires": {
@@ -7598,19 +7598,19 @@
     },
     "object-hash": {
       "version": "1.3.1",
-      "resolved": "https://registry.npm.taobao.org/object-hash/download/object-hash-1.3.1.tgz",
+      "resolved": "https://registry.npmjs.org/object-hash/-/object-hash-1.3.1.tgz",
       "integrity": "sha1-/eRSCYqVHLFF8Dm7fUVUSd3BJt8=",
       "dev": true
     },
     "object-keys": {
       "version": "1.1.1",
-      "resolved": "https://registry.npm.taobao.org/object-keys/download/object-keys-1.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
       "integrity": "sha1-HEfyct8nfzsdrwYWd9nILiMixg4=",
       "dev": true
     },
     "object-visit": {
       "version": "1.0.1",
-      "resolved": "https://registry.npm.taobao.org/object-visit/download/object-visit-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/object-visit/-/object-visit-1.0.1.tgz",
       "integrity": "sha1-95xEk68MU3e1n+OdOV5BBC3QRbs=",
       "dev": true,
       "requires": {
@@ -7619,7 +7619,7 @@
     },
     "object.assign": {
       "version": "4.1.0",
-      "resolved": "https://registry.npm.taobao.org/object.assign/download/object.assign-4.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.0.tgz",
       "integrity": "sha1-lovxEA15Vrs8oIbwBvhGs7xACNo=",
       "dev": true,
       "requires": {
@@ -7631,7 +7631,7 @@
     },
     "object.getownpropertydescriptors": {
       "version": "2.0.3",
-      "resolved": "https://registry.npm.taobao.org/object.getownpropertydescriptors/download/object.getownpropertydescriptors-2.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/object.getownpropertydescriptors/-/object.getownpropertydescriptors-2.0.3.tgz",
       "integrity": "sha1-h1jIRvW0B62rDyNuCYbxSwUcqhY=",
       "dev": true,
       "requires": {
@@ -7641,7 +7641,7 @@
     },
     "object.pick": {
       "version": "1.3.0",
-      "resolved": "https://registry.npm.taobao.org/object.pick/download/object.pick-1.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/object.pick/-/object.pick-1.3.0.tgz",
       "integrity": "sha1-h6EKxMFpS9Lhy/U1kaZhQftd10c=",
       "dev": true,
       "requires": {
@@ -7650,7 +7650,7 @@
     },
     "object.values": {
       "version": "1.1.0",
-      "resolved": "https://registry.npm.taobao.org/object.values/download/object.values-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/object.values/-/object.values-1.1.0.tgz",
       "integrity": "sha1-v2gQ712j5TJXkOqqK+IT6oRiTak=",
       "dev": true,
       "requires": {
@@ -7662,13 +7662,13 @@
     },
     "obuf": {
       "version": "1.1.2",
-      "resolved": "https://registry.npm.taobao.org/obuf/download/obuf-1.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/obuf/-/obuf-1.1.2.tgz",
       "integrity": "sha1-Cb6jND1BhZ69RGKS0RydTbYZCE4=",
       "dev": true
     },
     "on-finished": {
       "version": "2.3.0",
-      "resolved": "https://registry.npm.taobao.org/on-finished/download/on-finished-2.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
       "integrity": "sha1-IPEzZIGwg811M3mSoWlxqi2QaUc=",
       "dev": true,
       "requires": {
@@ -7677,13 +7677,13 @@
     },
     "on-headers": {
       "version": "1.0.2",
-      "resolved": "https://registry.npm.taobao.org/on-headers/download/on-headers-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/on-headers/-/on-headers-1.0.2.tgz",
       "integrity": "sha1-dysK5qqlJcOZ5Imt+tkMQD6zwo8=",
       "dev": true
     },
     "once": {
       "version": "1.4.0",
-      "resolved": "https://registry.npm.taobao.org/once/download/once-1.4.0.tgz",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
       "dev": true,
       "requires": {
@@ -7692,7 +7692,7 @@
     },
     "onetime": {
       "version": "2.0.1",
-      "resolved": "https://registry.npm.taobao.org/onetime/download/onetime-2.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-2.0.1.tgz",
       "integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=",
       "dev": true,
       "requires": {
@@ -7701,7 +7701,7 @@
     },
     "open": {
       "version": "6.4.0",
-      "resolved": "https://registry.npm.taobao.org/open/download/open-6.4.0.tgz",
+      "resolved": "https://registry.npmjs.org/open/-/open-6.4.0.tgz",
       "integrity": "sha1-XBPpbQ3IlGhhZPGJZez+iJ7PyKk=",
       "dev": true,
       "requires": {
@@ -7710,13 +7710,13 @@
     },
     "opener": {
       "version": "1.5.1",
-      "resolved": "https://registry.npm.taobao.org/opener/download/opener-1.5.1.tgz",
+      "resolved": "https://registry.npmjs.org/opener/-/opener-1.5.1.tgz",
       "integrity": "sha1-bS8Od/GgrwAyrKcWwsH7uOfoq+0=",
       "dev": true
     },
     "opn": {
       "version": "5.5.0",
-      "resolved": "https://registry.npm.taobao.org/opn/download/opn-5.5.0.tgz?cache=0&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fopn%2Fdownload%2Fopn-5.5.0.tgz",
+      "resolved": "https://registry.npmjs.org/opn/-/opn-5.5.0.tgz",
       "integrity": "sha1-/HFk+rVtI1kExRw7J9pnWMo7m/w=",
       "dev": true,
       "requires": {
@@ -7725,7 +7725,7 @@
     },
     "optionator": {
       "version": "0.8.2",
-      "resolved": "https://registry.npm.taobao.org/optionator/download/optionator-0.8.2.tgz",
+      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.2.tgz",
       "integrity": "sha1-NkxeQJ0/TWMB1sC0wFu6UBgK62Q=",
       "dev": true,
       "requires": {
@@ -7739,7 +7739,7 @@
     },
     "ora": {
       "version": "3.4.0",
-      "resolved": "https://registry.npm.taobao.org/ora/download/ora-3.4.0.tgz",
+      "resolved": "https://registry.npmjs.org/ora/-/ora-3.4.0.tgz",
       "integrity": "sha1-vwdSSRBZo+8+1MhQl1Md6f280xg=",
       "dev": true,
       "requires": {
@@ -7753,7 +7753,7 @@
     },
     "original": {
       "version": "1.0.2",
-      "resolved": "https://registry.npm.taobao.org/original/download/original-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/original/-/original-1.0.2.tgz",
       "integrity": "sha1-5EKmHP/hxf0gpl8yYcJmY7MD8l8=",
       "dev": true,
       "requires": {
@@ -7762,13 +7762,13 @@
     },
     "os-browserify": {
       "version": "0.3.0",
-      "resolved": "https://registry.npm.taobao.org/os-browserify/download/os-browserify-0.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/os-browserify/-/os-browserify-0.3.0.tgz",
       "integrity": "sha1-hUNzx/XCMVkU/Jv8a9gjj92h7Cc=",
       "dev": true
     },
     "os-locale": {
       "version": "3.1.0",
-      "resolved": "https://registry.npm.taobao.org/os-locale/download/os-locale-3.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-3.1.0.tgz",
       "integrity": "sha1-qAKm7hfyTBBIOrmTVxnO9O0Wvxo=",
       "dev": true,
       "requires": {
@@ -7779,31 +7779,31 @@
     },
     "os-tmpdir": {
       "version": "1.0.2",
-      "resolved": "https://registry.npm.taobao.org/os-tmpdir/download/os-tmpdir-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
       "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
       "dev": true
     },
     "p-defer": {
       "version": "1.0.0",
-      "resolved": "https://registry.npm.taobao.org/p-defer/download/p-defer-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/p-defer/-/p-defer-1.0.0.tgz",
       "integrity": "sha1-n26xgvbJqozXQwBKfU+WsZaw+ww=",
       "dev": true
     },
     "p-finally": {
       "version": "1.0.0",
-      "resolved": "https://registry.npm.taobao.org/p-finally/download/p-finally-1.0.0.tgz?cache=0&sync_timestamp=1560983840673&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fp-finally%2Fdownload%2Fp-finally-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
       "integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4=",
       "dev": true
     },
     "p-is-promise": {
       "version": "2.1.0",
-      "resolved": "https://registry.npm.taobao.org/p-is-promise/download/p-is-promise-2.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/p-is-promise/-/p-is-promise-2.1.0.tgz",
       "integrity": "sha1-kYzrrqJIpiz3/6uOO8qMX4gvxC4=",
       "dev": true
     },
     "p-limit": {
       "version": "1.3.0",
-      "resolved": "https://registry.npm.taobao.org/p-limit/download/p-limit-1.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.3.0.tgz",
       "integrity": "sha1-uGvV8MJWkJEcdZD8v8IBDVSzzLg=",
       "dev": true,
       "requires": {
@@ -7812,7 +7812,7 @@
     },
     "p-locate": {
       "version": "2.0.0",
-      "resolved": "https://registry.npm.taobao.org/p-locate/download/p-locate-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
       "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
       "dev": true,
       "requires": {
@@ -7821,13 +7821,13 @@
     },
     "p-map": {
       "version": "2.1.0",
-      "resolved": "https://registry.npm.taobao.org/p-map/download/p-map-2.1.0.tgz?cache=0&sync_timestamp=1563032875018&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fp-map%2Fdownload%2Fp-map-2.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/p-map/-/p-map-2.1.0.tgz",
       "integrity": "sha1-MQko/u+cnsxltosXaTAYpmXOoXU=",
       "dev": true
     },
     "p-retry": {
       "version": "3.0.1",
-      "resolved": "https://registry.npm.taobao.org/p-retry/download/p-retry-3.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/p-retry/-/p-retry-3.0.1.tgz",
       "integrity": "sha1-MWtMiJPiyNwc+okfQGxLQivr8yg=",
       "dev": true,
       "requires": {
@@ -7836,19 +7836,19 @@
     },
     "p-try": {
       "version": "1.0.0",
-      "resolved": "https://registry.npm.taobao.org/p-try/download/p-try-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
       "integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M=",
       "dev": true
     },
     "pako": {
       "version": "1.0.10",
-      "resolved": "https://registry.npm.taobao.org/pako/download/pako-1.0.10.tgz",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.10.tgz",
       "integrity": "sha1-Qyi621CGpCaqkPVBl31JVdpclzI=",
       "dev": true
     },
     "parallel-transform": {
       "version": "1.1.0",
-      "resolved": "https://registry.npm.taobao.org/parallel-transform/download/parallel-transform-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/parallel-transform/-/parallel-transform-1.1.0.tgz",
       "integrity": "sha1-1BDwZbBdojCB/NEPKIVMKb2jOwY=",
       "dev": true,
       "requires": {
@@ -7859,7 +7859,7 @@
     },
     "param-case": {
       "version": "2.1.1",
-      "resolved": "https://registry.npm.taobao.org/param-case/download/param-case-2.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/param-case/-/param-case-2.1.1.tgz",
       "integrity": "sha1-35T9jPZTHs915r75oIWPvHK+Ikc=",
       "dev": true,
       "requires": {
@@ -7868,7 +7868,7 @@
     },
     "parent-module": {
       "version": "1.0.1",
-      "resolved": "https://registry.npm.taobao.org/parent-module/download/parent-module-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
       "integrity": "sha1-aR0nCeeMefrjoVZiJFLQB2LKqqI=",
       "dev": true,
       "requires": {
@@ -7877,7 +7877,7 @@
       "dependencies": {
         "callsites": {
           "version": "3.1.0",
-          "resolved": "https://registry.npm.taobao.org/callsites/download/callsites-3.1.0.tgz",
+          "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
           "integrity": "sha1-s2MKvYlDQy9Us/BRkjjjPNffL3M=",
           "dev": true
         }
@@ -7885,7 +7885,7 @@
     },
     "parse-asn1": {
       "version": "5.1.4",
-      "resolved": "https://registry.npm.taobao.org/parse-asn1/download/parse-asn1-5.1.4.tgz",
+      "resolved": "https://registry.npmjs.org/parse-asn1/-/parse-asn1-5.1.4.tgz",
       "integrity": "sha1-N/Zij4I/vesic7TVQENKIvPvH8w=",
       "dev": true,
       "requires": {
@@ -7899,7 +7899,7 @@
     },
     "parse-json": {
       "version": "4.0.0",
-      "resolved": "https://registry.npm.taobao.org/parse-json/download/parse-json-4.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
       "integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
       "dev": true,
       "requires": {
@@ -7909,73 +7909,73 @@
     },
     "parse5": {
       "version": "4.0.0",
-      "resolved": "https://registry.npm.taobao.org/parse5/download/parse5-4.0.0.tgz?cache=0&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fparse5%2Fdownload%2Fparse5-4.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-4.0.0.tgz",
       "integrity": "sha1-bXhlbj2o14tOwLkG98CO8d/j9gg=",
       "dev": true
     },
     "parseurl": {
       "version": "1.3.3",
-      "resolved": "https://registry.npm.taobao.org/parseurl/download/parseurl-1.3.3.tgz",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
       "integrity": "sha1-naGee+6NEt/wUT7Vt2lXeTvC6NQ=",
       "dev": true
     },
     "pascalcase": {
       "version": "0.1.1",
-      "resolved": "https://registry.npm.taobao.org/pascalcase/download/pascalcase-0.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/pascalcase/-/pascalcase-0.1.1.tgz",
       "integrity": "sha1-s2PlXoAGym/iF4TS2yK9FdeRfxQ=",
       "dev": true
     },
     "path-browserify": {
       "version": "0.0.1",
-      "resolved": "https://registry.npm.taobao.org/path-browserify/download/path-browserify-0.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-0.0.1.tgz",
       "integrity": "sha1-5sTd1+06onxoogzE5Q4aTug7vEo=",
       "dev": true
     },
     "path-dirname": {
       "version": "1.0.2",
-      "resolved": "https://registry.npm.taobao.org/path-dirname/download/path-dirname-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/path-dirname/-/path-dirname-1.0.2.tgz",
       "integrity": "sha1-zDPSTVJeCZpTiMAzbG4yuRYGCeA=",
       "dev": true
     },
     "path-exists": {
       "version": "3.0.0",
-      "resolved": "https://registry.npm.taobao.org/path-exists/download/path-exists-3.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
       "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
       "dev": true
     },
     "path-is-absolute": {
       "version": "1.0.1",
-      "resolved": "https://registry.npm.taobao.org/path-is-absolute/download/path-is-absolute-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
       "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
       "dev": true
     },
     "path-is-inside": {
       "version": "1.0.2",
-      "resolved": "https://registry.npm.taobao.org/path-is-inside/download/path-is-inside-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/path-is-inside/-/path-is-inside-1.0.2.tgz",
       "integrity": "sha1-NlQX3t5EQw0cEa9hAn+s8HS9/FM=",
       "dev": true
     },
     "path-key": {
       "version": "2.0.1",
-      "resolved": "https://registry.npm.taobao.org/path-key/download/path-key-2.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
       "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A=",
       "dev": true
     },
     "path-parse": {
       "version": "1.0.6",
-      "resolved": "https://registry.npm.taobao.org/path-parse/download/path-parse-1.0.6.tgz",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
       "integrity": "sha1-1i27VnlAXXLEc37FhgDp3c8G0kw=",
       "dev": true
     },
     "path-to-regexp": {
       "version": "0.1.7",
-      "resolved": "https://registry.npm.taobao.org/path-to-regexp/download/path-to-regexp-0.1.7.tgz?cache=0&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fpath-to-regexp%2Fdownload%2Fpath-to-regexp-0.1.7.tgz",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
       "integrity": "sha1-32BBeABfUi8V60SQ5yR6G/qmf4w=",
       "dev": true
     },
     "path-type": {
       "version": "3.0.0",
-      "resolved": "https://registry.npm.taobao.org/path-type/download/path-type-3.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/path-type/-/path-type-3.0.0.tgz",
       "integrity": "sha1-zvMdyOCho7sNEFwM2Xzzv0f0428=",
       "dev": true,
       "requires": {
@@ -7984,7 +7984,7 @@
       "dependencies": {
         "pify": {
           "version": "3.0.0",
-          "resolved": "https://registry.npm.taobao.org/pify/download/pify-3.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
           "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
           "dev": true
         }
@@ -7992,7 +7992,7 @@
     },
     "pbkdf2": {
       "version": "3.0.17",
-      "resolved": "https://registry.npm.taobao.org/pbkdf2/download/pbkdf2-3.0.17.tgz",
+      "resolved": "https://registry.npmjs.org/pbkdf2/-/pbkdf2-3.0.17.tgz",
       "integrity": "sha1-l2wgZTBhexTrsyEUI597CTNuk6Y=",
       "dev": true,
       "requires": {
@@ -8005,25 +8005,25 @@
     },
     "performance-now": {
       "version": "2.1.0",
-      "resolved": "https://registry.npm.taobao.org/performance-now/download/performance-now-2.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
       "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=",
       "dev": true
     },
     "pify": {
       "version": "4.0.1",
-      "resolved": "https://registry.npm.taobao.org/pify/download/pify-4.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
       "integrity": "sha1-SyzSXFDVmHNcUCkiJP2MbfQeMjE=",
       "dev": true
     },
     "pinkie": {
       "version": "2.0.4",
-      "resolved": "https://registry.npm.taobao.org/pinkie/download/pinkie-2.0.4.tgz",
+      "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
       "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA=",
       "dev": true
     },
     "pinkie-promise": {
       "version": "2.0.1",
-      "resolved": "https://registry.npm.taobao.org/pinkie-promise/download/pinkie-promise-2.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
       "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
       "dev": true,
       "requires": {
@@ -8032,7 +8032,7 @@
     },
     "pkg-dir": {
       "version": "3.0.0",
-      "resolved": "https://registry.npm.taobao.org/pkg-dir/download/pkg-dir-3.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-3.0.0.tgz",
       "integrity": "sha1-J0kCDyOe2ZCIGx9xIQ1R62UjvqM=",
       "dev": true,
       "requires": {
@@ -8041,7 +8041,7 @@
       "dependencies": {
         "find-up": {
           "version": "3.0.0",
-          "resolved": "https://registry.npm.taobao.org/find-up/download/find-up-3.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
           "integrity": "sha1-SRafHXmTQwZG2mHsxa41XCHJe3M=",
           "dev": true,
           "requires": {
@@ -8050,7 +8050,7 @@
         },
         "locate-path": {
           "version": "3.0.0",
-          "resolved": "https://registry.npm.taobao.org/locate-path/download/locate-path-3.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
           "integrity": "sha1-2+w7OrdZdYBxtY/ln8QYca8hQA4=",
           "dev": true,
           "requires": {
@@ -8060,7 +8060,7 @@
         },
         "p-limit": {
           "version": "2.2.0",
-          "resolved": "https://registry.npm.taobao.org/p-limit/download/p-limit-2.2.0.tgz",
+          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.2.0.tgz",
           "integrity": "sha1-QXyZQeYCepq8ulCS3SkE4lW1+8I=",
           "dev": true,
           "requires": {
@@ -8069,7 +8069,7 @@
         },
         "p-locate": {
           "version": "3.0.0",
-          "resolved": "https://registry.npm.taobao.org/p-locate/download/p-locate-3.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
           "integrity": "sha1-Mi1poFwCZLJZl9n0DNiokasAZKQ=",
           "dev": true,
           "requires": {
@@ -8078,7 +8078,7 @@
         },
         "p-try": {
           "version": "2.2.0",
-          "resolved": "https://registry.npm.taobao.org/p-try/download/p-try-2.2.0.tgz",
+          "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
           "integrity": "sha1-yyhoVA4xPWHeWPr741zpAE1VQOY=",
           "dev": true
         }
@@ -8086,7 +8086,7 @@
     },
     "pkg-up": {
       "version": "2.0.0",
-      "resolved": "https://registry.npm.taobao.org/pkg-up/download/pkg-up-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/pkg-up/-/pkg-up-2.0.0.tgz",
       "integrity": "sha1-yBmscoBZpGHKscOImivjxJoATX8=",
       "dev": true,
       "requires": {
@@ -8095,14 +8095,14 @@
     },
     "pluralize": {
       "version": "7.0.0",
-      "resolved": "https://registry.npm.taobao.org/pluralize/download/pluralize-7.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/pluralize/-/pluralize-7.0.0.tgz",
       "integrity": "sha1-KYuJ34uTsCIdv0Ia0rGx6iP8Z3c=",
       "dev": true,
       "optional": true
     },
     "portfinder": {
       "version": "1.0.21",
-      "resolved": "https://registry.npm.taobao.org/portfinder/download/portfinder-1.0.21.tgz?cache=0&sync_timestamp=1562941556574&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fportfinder%2Fdownload%2Fportfinder-1.0.21.tgz",
+      "resolved": "https://registry.npmjs.org/portfinder/-/portfinder-1.0.21.tgz",
       "integrity": "sha1-YOE5e5WsFwdJ23ADTs4wa5on4yQ=",
       "dev": true,
       "requires": {
@@ -8113,7 +8113,7 @@
       "dependencies": {
         "debug": {
           "version": "2.6.9",
-          "resolved": "https://registry.npm.taobao.org/debug/download/debug-2.6.9.tgz",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
           "integrity": "sha1-XRKFFd8TT/Mn6QpMk/Tgd6U2NB8=",
           "dev": true,
           "requires": {
@@ -8122,7 +8122,7 @@
         },
         "ms": {
           "version": "2.0.0",
-          "resolved": "https://registry.npm.taobao.org/ms/download/ms-2.0.0.tgz?cache=0&sync_timestamp=1559842528856&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fms%2Fdownload%2Fms-2.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
           "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
           "dev": true
         }
@@ -8130,13 +8130,13 @@
     },
     "posix-character-classes": {
       "version": "0.1.1",
-      "resolved": "https://registry.npm.taobao.org/posix-character-classes/download/posix-character-classes-0.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/posix-character-classes/-/posix-character-classes-0.1.1.tgz",
       "integrity": "sha1-AerA/jta9xoqbAL+q7jB/vfgDqs=",
       "dev": true
     },
     "postcss": {
       "version": "7.0.17",
-      "resolved": "https://registry.npm.taobao.org/postcss/download/postcss-7.0.17.tgz?cache=0&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fpostcss%2Fdownload%2Fpostcss-7.0.17.tgz",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.17.tgz",
       "integrity": "sha1-TaG9/1Mi1KCsqrTYfz54JDa60x8=",
       "dev": true,
       "requires": {
@@ -8147,13 +8147,13 @@
       "dependencies": {
         "source-map": {
           "version": "0.6.1",
-          "resolved": "https://registry.npm.taobao.org/source-map/download/source-map-0.6.1.tgz",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
           "integrity": "sha1-dHIq8y6WFOnCh6jQu95IteLxomM=",
           "dev": true
         },
         "supports-color": {
           "version": "6.1.0",
-          "resolved": "https://registry.npm.taobao.org/supports-color/download/supports-color-6.1.0.tgz",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
           "integrity": "sha1-B2Srxpxj1ayELdSGfo0CXogN+PM=",
           "dev": true,
           "requires": {
@@ -8164,7 +8164,7 @@
     },
     "postcss-calc": {
       "version": "7.0.1",
-      "resolved": "https://registry.npm.taobao.org/postcss-calc/download/postcss-calc-7.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/postcss-calc/-/postcss-calc-7.0.1.tgz",
       "integrity": "sha1-Ntd7qwI7Dsu5eJ2E3LI8SUEUVDY=",
       "dev": true,
       "requires": {
@@ -8176,7 +8176,7 @@
     },
     "postcss-colormin": {
       "version": "4.0.3",
-      "resolved": "https://registry.npm.taobao.org/postcss-colormin/download/postcss-colormin-4.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/postcss-colormin/-/postcss-colormin-4.0.3.tgz",
       "integrity": "sha1-rgYLzpPteUrHEmTwgTLVUJVr04E=",
       "dev": true,
       "requires": {
@@ -8189,7 +8189,7 @@
     },
     "postcss-convert-values": {
       "version": "4.0.1",
-      "resolved": "https://registry.npm.taobao.org/postcss-convert-values/download/postcss-convert-values-4.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/postcss-convert-values/-/postcss-convert-values-4.0.1.tgz",
       "integrity": "sha1-yjgT7U2g+BL51DcDWE5Enr4Ymn8=",
       "dev": true,
       "requires": {
@@ -8199,7 +8199,7 @@
     },
     "postcss-discard-comments": {
       "version": "4.0.2",
-      "resolved": "https://registry.npm.taobao.org/postcss-discard-comments/download/postcss-discard-comments-4.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/postcss-discard-comments/-/postcss-discard-comments-4.0.2.tgz",
       "integrity": "sha1-H7q9LCRr/2qq15l7KwkY9NevQDM=",
       "dev": true,
       "requires": {
@@ -8208,7 +8208,7 @@
     },
     "postcss-discard-duplicates": {
       "version": "4.0.2",
-      "resolved": "https://registry.npm.taobao.org/postcss-discard-duplicates/download/postcss-discard-duplicates-4.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/postcss-discard-duplicates/-/postcss-discard-duplicates-4.0.2.tgz",
       "integrity": "sha1-P+EzzTyCKC5VD8myORdqkge3hOs=",
       "dev": true,
       "requires": {
@@ -8217,7 +8217,7 @@
     },
     "postcss-discard-empty": {
       "version": "4.0.1",
-      "resolved": "https://registry.npm.taobao.org/postcss-discard-empty/download/postcss-discard-empty-4.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/postcss-discard-empty/-/postcss-discard-empty-4.0.1.tgz",
       "integrity": "sha1-yMlR6fc+2UKAGUWERKAq2Qu592U=",
       "dev": true,
       "requires": {
@@ -8226,7 +8226,7 @@
     },
     "postcss-discard-overridden": {
       "version": "4.0.1",
-      "resolved": "https://registry.npm.taobao.org/postcss-discard-overridden/download/postcss-discard-overridden-4.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/postcss-discard-overridden/-/postcss-discard-overridden-4.0.1.tgz",
       "integrity": "sha1-ZSrvipZybwKfXj4AFG7npOdV/1c=",
       "dev": true,
       "requires": {
@@ -8235,7 +8235,7 @@
     },
     "postcss-load-config": {
       "version": "2.1.0",
-      "resolved": "https://registry.npm.taobao.org/postcss-load-config/download/postcss-load-config-2.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/postcss-load-config/-/postcss-load-config-2.1.0.tgz",
       "integrity": "sha1-yE1pK3u3tB3c7ZTuYuirMbQXsAM=",
       "dev": true,
       "requires": {
@@ -8245,7 +8245,7 @@
     },
     "postcss-loader": {
       "version": "3.0.0",
-      "resolved": "https://registry.npm.taobao.org/postcss-loader/download/postcss-loader-3.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/postcss-loader/-/postcss-loader-3.0.0.tgz",
       "integrity": "sha1-a5eUPkfHLYRfqeA/Jzdz1OjdbC0=",
       "dev": true,
       "requires": {
@@ -8257,7 +8257,7 @@
       "dependencies": {
         "schema-utils": {
           "version": "1.0.0",
-          "resolved": "https://registry.npm.taobao.org/schema-utils/download/schema-utils-1.0.0.tgz?cache=0&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fschema-utils%2Fdownload%2Fschema-utils-1.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-1.0.0.tgz",
           "integrity": "sha1-C3mpMgTXtgDUsoUNH2bCo0lRx3A=",
           "dev": true,
           "requires": {
@@ -8270,7 +8270,7 @@
     },
     "postcss-merge-longhand": {
       "version": "4.0.11",
-      "resolved": "https://registry.npm.taobao.org/postcss-merge-longhand/download/postcss-merge-longhand-4.0.11.tgz",
+      "resolved": "https://registry.npmjs.org/postcss-merge-longhand/-/postcss-merge-longhand-4.0.11.tgz",
       "integrity": "sha1-YvSaE+Sg7gTnuY9CuxYGLKJUniQ=",
       "dev": true,
       "requires": {
@@ -8282,7 +8282,7 @@
     },
     "postcss-merge-rules": {
       "version": "4.0.3",
-      "resolved": "https://registry.npm.taobao.org/postcss-merge-rules/download/postcss-merge-rules-4.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/postcss-merge-rules/-/postcss-merge-rules-4.0.3.tgz",
       "integrity": "sha1-NivqT/Wh+Y5AdacTxsslrv75plA=",
       "dev": true,
       "requires": {
@@ -8296,7 +8296,7 @@
       "dependencies": {
         "postcss-selector-parser": {
           "version": "3.1.1",
-          "resolved": "https://registry.npm.taobao.org/postcss-selector-parser/download/postcss-selector-parser-3.1.1.tgz",
+          "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-3.1.1.tgz",
           "integrity": "sha1-T4dfSvsMllc9XPTXQBGu4lCn6GU=",
           "dev": true,
           "requires": {
@@ -8309,7 +8309,7 @@
     },
     "postcss-minify-font-values": {
       "version": "4.0.2",
-      "resolved": "https://registry.npm.taobao.org/postcss-minify-font-values/download/postcss-minify-font-values-4.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/postcss-minify-font-values/-/postcss-minify-font-values-4.0.2.tgz",
       "integrity": "sha1-zUw0TM5HQ0P6xdgiBqssvLiv1aY=",
       "dev": true,
       "requires": {
@@ -8319,7 +8319,7 @@
     },
     "postcss-minify-gradients": {
       "version": "4.0.2",
-      "resolved": "https://registry.npm.taobao.org/postcss-minify-gradients/download/postcss-minify-gradients-4.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/postcss-minify-gradients/-/postcss-minify-gradients-4.0.2.tgz",
       "integrity": "sha1-k7KcL/UJnFNe7NpWxKpuZlpmNHE=",
       "dev": true,
       "requires": {
@@ -8331,7 +8331,7 @@
     },
     "postcss-minify-params": {
       "version": "4.0.2",
-      "resolved": "https://registry.npm.taobao.org/postcss-minify-params/download/postcss-minify-params-4.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/postcss-minify-params/-/postcss-minify-params-4.0.2.tgz",
       "integrity": "sha1-a5zvAwwR41Jh+V9hjJADbWgNuHQ=",
       "dev": true,
       "requires": {
@@ -8345,7 +8345,7 @@
     },
     "postcss-minify-selectors": {
       "version": "4.0.2",
-      "resolved": "https://registry.npm.taobao.org/postcss-minify-selectors/download/postcss-minify-selectors-4.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/postcss-minify-selectors/-/postcss-minify-selectors-4.0.2.tgz",
       "integrity": "sha1-4uXrQL/uUA0M2SQ1APX46kJi+9g=",
       "dev": true,
       "requires": {
@@ -8357,7 +8357,7 @@
       "dependencies": {
         "postcss-selector-parser": {
           "version": "3.1.1",
-          "resolved": "https://registry.npm.taobao.org/postcss-selector-parser/download/postcss-selector-parser-3.1.1.tgz",
+          "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-3.1.1.tgz",
           "integrity": "sha1-T4dfSvsMllc9XPTXQBGu4lCn6GU=",
           "dev": true,
           "requires": {
@@ -8370,7 +8370,7 @@
     },
     "postcss-modules-extract-imports": {
       "version": "1.2.1",
-      "resolved": "https://registry.npm.taobao.org/postcss-modules-extract-imports/download/postcss-modules-extract-imports-1.2.1.tgz?cache=0&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fpostcss-modules-extract-imports%2Fdownload%2Fpostcss-modules-extract-imports-1.2.1.tgz",
+      "resolved": "https://registry.npmjs.org/postcss-modules-extract-imports/-/postcss-modules-extract-imports-1.2.1.tgz",
       "integrity": "sha1-3IfjQUjsfqtfeR981YSYMzdbdBo=",
       "dev": true,
       "requires": {
@@ -8379,7 +8379,7 @@
       "dependencies": {
         "postcss": {
           "version": "6.0.23",
-          "resolved": "https://registry.npm.taobao.org/postcss/download/postcss-6.0.23.tgz?cache=0&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fpostcss%2Fdownload%2Fpostcss-6.0.23.tgz",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.23.tgz",
           "integrity": "sha1-YcgswyisYOZ3ZF+XkFTrmLwOMyQ=",
           "dev": true,
           "requires": {
@@ -8390,7 +8390,7 @@
         },
         "source-map": {
           "version": "0.6.1",
-          "resolved": "https://registry.npm.taobao.org/source-map/download/source-map-0.6.1.tgz",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
           "integrity": "sha1-dHIq8y6WFOnCh6jQu95IteLxomM=",
           "dev": true
         }
@@ -8398,7 +8398,7 @@
     },
     "postcss-modules-local-by-default": {
       "version": "1.2.0",
-      "resolved": "https://registry.npm.taobao.org/postcss-modules-local-by-default/download/postcss-modules-local-by-default-1.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/postcss-modules-local-by-default/-/postcss-modules-local-by-default-1.2.0.tgz",
       "integrity": "sha1-99gMOYxaOT+nlkRmvRlQCn1hwGk=",
       "dev": true,
       "requires": {
@@ -8408,7 +8408,7 @@
       "dependencies": {
         "postcss": {
           "version": "6.0.23",
-          "resolved": "https://registry.npm.taobao.org/postcss/download/postcss-6.0.23.tgz?cache=0&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fpostcss%2Fdownload%2Fpostcss-6.0.23.tgz",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.23.tgz",
           "integrity": "sha1-YcgswyisYOZ3ZF+XkFTrmLwOMyQ=",
           "dev": true,
           "requires": {
@@ -8419,7 +8419,7 @@
         },
         "source-map": {
           "version": "0.6.1",
-          "resolved": "https://registry.npm.taobao.org/source-map/download/source-map-0.6.1.tgz",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
           "integrity": "sha1-dHIq8y6WFOnCh6jQu95IteLxomM=",
           "dev": true
         }
@@ -8427,7 +8427,7 @@
     },
     "postcss-modules-scope": {
       "version": "1.1.0",
-      "resolved": "https://registry.npm.taobao.org/postcss-modules-scope/download/postcss-modules-scope-1.1.0.tgz?cache=0&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fpostcss-modules-scope%2Fdownload%2Fpostcss-modules-scope-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/postcss-modules-scope/-/postcss-modules-scope-1.1.0.tgz",
       "integrity": "sha1-1upkmUx5+XtipytCb75gVqGUu5A=",
       "dev": true,
       "requires": {
@@ -8437,7 +8437,7 @@
       "dependencies": {
         "postcss": {
           "version": "6.0.23",
-          "resolved": "https://registry.npm.taobao.org/postcss/download/postcss-6.0.23.tgz?cache=0&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fpostcss%2Fdownload%2Fpostcss-6.0.23.tgz",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.23.tgz",
           "integrity": "sha1-YcgswyisYOZ3ZF+XkFTrmLwOMyQ=",
           "dev": true,
           "requires": {
@@ -8448,7 +8448,7 @@
         },
         "source-map": {
           "version": "0.6.1",
-          "resolved": "https://registry.npm.taobao.org/source-map/download/source-map-0.6.1.tgz",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
           "integrity": "sha1-dHIq8y6WFOnCh6jQu95IteLxomM=",
           "dev": true
         }
@@ -8456,7 +8456,7 @@
     },
     "postcss-modules-values": {
       "version": "1.3.0",
-      "resolved": "https://registry.npm.taobao.org/postcss-modules-values/download/postcss-modules-values-1.3.0.tgz?cache=0&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fpostcss-modules-values%2Fdownload%2Fpostcss-modules-values-1.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/postcss-modules-values/-/postcss-modules-values-1.3.0.tgz",
       "integrity": "sha1-7P+p1+GSUYOJ9CrQ6D9yrsRW6iA=",
       "dev": true,
       "requires": {
@@ -8466,7 +8466,7 @@
       "dependencies": {
         "postcss": {
           "version": "6.0.23",
-          "resolved": "https://registry.npm.taobao.org/postcss/download/postcss-6.0.23.tgz?cache=0&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fpostcss%2Fdownload%2Fpostcss-6.0.23.tgz",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.23.tgz",
           "integrity": "sha1-YcgswyisYOZ3ZF+XkFTrmLwOMyQ=",
           "dev": true,
           "requires": {
@@ -8477,7 +8477,7 @@
         },
         "source-map": {
           "version": "0.6.1",
-          "resolved": "https://registry.npm.taobao.org/source-map/download/source-map-0.6.1.tgz",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
           "integrity": "sha1-dHIq8y6WFOnCh6jQu95IteLxomM=",
           "dev": true
         }
@@ -8485,7 +8485,7 @@
     },
     "postcss-normalize-charset": {
       "version": "4.0.1",
-      "resolved": "https://registry.npm.taobao.org/postcss-normalize-charset/download/postcss-normalize-charset-4.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/postcss-normalize-charset/-/postcss-normalize-charset-4.0.1.tgz",
       "integrity": "sha1-izWt067oOhNrBHHg1ZvlilAoXdQ=",
       "dev": true,
       "requires": {
@@ -8494,7 +8494,7 @@
     },
     "postcss-normalize-display-values": {
       "version": "4.0.2",
-      "resolved": "https://registry.npm.taobao.org/postcss-normalize-display-values/download/postcss-normalize-display-values-4.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/postcss-normalize-display-values/-/postcss-normalize-display-values-4.0.2.tgz",
       "integrity": "sha1-Db4EpM6QY9RmftK+R2u4MMglk1o=",
       "dev": true,
       "requires": {
@@ -8505,7 +8505,7 @@
     },
     "postcss-normalize-positions": {
       "version": "4.0.2",
-      "resolved": "https://registry.npm.taobao.org/postcss-normalize-positions/download/postcss-normalize-positions-4.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/postcss-normalize-positions/-/postcss-normalize-positions-4.0.2.tgz",
       "integrity": "sha1-BfdX+E8mBDc3g2ipH4ky1LECkX8=",
       "dev": true,
       "requires": {
@@ -8517,7 +8517,7 @@
     },
     "postcss-normalize-repeat-style": {
       "version": "4.0.2",
-      "resolved": "https://registry.npm.taobao.org/postcss-normalize-repeat-style/download/postcss-normalize-repeat-style-4.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/postcss-normalize-repeat-style/-/postcss-normalize-repeat-style-4.0.2.tgz",
       "integrity": "sha1-xOu8KJ85kaAo1EdRy90RkYsXkQw=",
       "dev": true,
       "requires": {
@@ -8529,7 +8529,7 @@
     },
     "postcss-normalize-string": {
       "version": "4.0.2",
-      "resolved": "https://registry.npm.taobao.org/postcss-normalize-string/download/postcss-normalize-string-4.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/postcss-normalize-string/-/postcss-normalize-string-4.0.2.tgz",
       "integrity": "sha1-zUTECrB6DHo23F6Zqs4eyk7CaQw=",
       "dev": true,
       "requires": {
@@ -8540,7 +8540,7 @@
     },
     "postcss-normalize-timing-functions": {
       "version": "4.0.2",
-      "resolved": "https://registry.npm.taobao.org/postcss-normalize-timing-functions/download/postcss-normalize-timing-functions-4.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/postcss-normalize-timing-functions/-/postcss-normalize-timing-functions-4.0.2.tgz",
       "integrity": "sha1-jgCcoqOUnNr4rSPmtquZy159KNk=",
       "dev": true,
       "requires": {
@@ -8551,7 +8551,7 @@
     },
     "postcss-normalize-unicode": {
       "version": "4.0.1",
-      "resolved": "https://registry.npm.taobao.org/postcss-normalize-unicode/download/postcss-normalize-unicode-4.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/postcss-normalize-unicode/-/postcss-normalize-unicode-4.0.1.tgz",
       "integrity": "sha1-hBvUj9zzAZrUuqdJOj02O1KuHPs=",
       "dev": true,
       "requires": {
@@ -8562,7 +8562,7 @@
     },
     "postcss-normalize-url": {
       "version": "4.0.1",
-      "resolved": "https://registry.npm.taobao.org/postcss-normalize-url/download/postcss-normalize-url-4.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/postcss-normalize-url/-/postcss-normalize-url-4.0.1.tgz",
       "integrity": "sha1-EOQ3+GvHx+WPe5ZS7YeNqqlfquE=",
       "dev": true,
       "requires": {
@@ -8574,7 +8574,7 @@
     },
     "postcss-normalize-whitespace": {
       "version": "4.0.2",
-      "resolved": "https://registry.npm.taobao.org/postcss-normalize-whitespace/download/postcss-normalize-whitespace-4.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/postcss-normalize-whitespace/-/postcss-normalize-whitespace-4.0.2.tgz",
       "integrity": "sha1-vx1AcP5Pzqh9E0joJdjMDF+qfYI=",
       "dev": true,
       "requires": {
@@ -8584,7 +8584,7 @@
     },
     "postcss-ordered-values": {
       "version": "4.1.2",
-      "resolved": "https://registry.npm.taobao.org/postcss-ordered-values/download/postcss-ordered-values-4.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/postcss-ordered-values/-/postcss-ordered-values-4.1.2.tgz",
       "integrity": "sha1-DPdcgg7H1cTSgBiVWeC1ceusDu4=",
       "dev": true,
       "requires": {
@@ -8595,7 +8595,7 @@
     },
     "postcss-reduce-initial": {
       "version": "4.0.3",
-      "resolved": "https://registry.npm.taobao.org/postcss-reduce-initial/download/postcss-reduce-initial-4.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/postcss-reduce-initial/-/postcss-reduce-initial-4.0.3.tgz",
       "integrity": "sha1-f9QuvqXpyBRgljniwuhK4nC6SN8=",
       "dev": true,
       "requires": {
@@ -8607,7 +8607,7 @@
     },
     "postcss-reduce-transforms": {
       "version": "4.0.2",
-      "resolved": "https://registry.npm.taobao.org/postcss-reduce-transforms/download/postcss-reduce-transforms-4.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/postcss-reduce-transforms/-/postcss-reduce-transforms-4.0.2.tgz",
       "integrity": "sha1-F++kBerMbge+NBSlyi0QdGgdTik=",
       "dev": true,
       "requires": {
@@ -8619,7 +8619,7 @@
     },
     "postcss-selector-parser": {
       "version": "5.0.0",
-      "resolved": "https://registry.npm.taobao.org/postcss-selector-parser/download/postcss-selector-parser-5.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-5.0.0.tgz",
       "integrity": "sha1-JJBENWaXsztk8aj3yAki3d7nGVw=",
       "dev": true,
       "requires": {
@@ -8630,7 +8630,7 @@
     },
     "postcss-svgo": {
       "version": "4.0.2",
-      "resolved": "https://registry.npm.taobao.org/postcss-svgo/download/postcss-svgo-4.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/postcss-svgo/-/postcss-svgo-4.0.2.tgz",
       "integrity": "sha1-F7mXvHEbMzurFDqu07jT1uPTglg=",
       "dev": true,
       "requires": {
@@ -8642,7 +8642,7 @@
     },
     "postcss-unique-selectors": {
       "version": "4.0.1",
-      "resolved": "https://registry.npm.taobao.org/postcss-unique-selectors/download/postcss-unique-selectors-4.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/postcss-unique-selectors/-/postcss-unique-selectors-4.0.1.tgz",
       "integrity": "sha1-lEaRHzKJv9ZMbWgPBzwDsfnuS6w=",
       "dev": true,
       "requires": {
@@ -8653,31 +8653,31 @@
     },
     "postcss-value-parser": {
       "version": "3.3.1",
-      "resolved": "https://registry.npm.taobao.org/postcss-value-parser/download/postcss-value-parser-3.3.1.tgz",
+      "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.3.1.tgz",
       "integrity": "sha1-n/giVH4okyE88cMO+lGsX9G6goE=",
       "dev": true
     },
     "prelude-ls": {
       "version": "1.1.2",
-      "resolved": "https://registry.npm.taobao.org/prelude-ls/download/prelude-ls-1.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
       "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=",
       "dev": true
     },
     "prepend-http": {
       "version": "2.0.0",
-      "resolved": "https://registry.npm.taobao.org/prepend-http/download/prepend-http-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-2.0.0.tgz",
       "integrity": "sha1-6SQ0v6XqjBn0HN/UAddBo8gZ2Jc=",
       "dev": true
     },
     "prettier": {
       "version": "1.16.3",
-      "resolved": "https://registry.npm.taobao.org/prettier/download/prettier-1.16.3.tgz?cache=0&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fprettier%2Fdownload%2Fprettier-1.16.3.tgz",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-1.16.3.tgz",
       "integrity": "sha1-jGIWhFO63vcC80tFtu6JlXSmpl0=",
       "dev": true
     },
     "pretty-error": {
       "version": "2.1.1",
-      "resolved": "https://registry.npm.taobao.org/pretty-error/download/pretty-error-2.1.1.tgz?cache=0&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fpretty-error%2Fdownload%2Fpretty-error-2.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/pretty-error/-/pretty-error-2.1.1.tgz",
       "integrity": "sha1-X0+HyPkeWuPzuoerTPXgOxoX8aM=",
       "dev": true,
       "requires": {
@@ -8687,37 +8687,37 @@
     },
     "private": {
       "version": "0.1.8",
-      "resolved": "https://registry.npm.taobao.org/private/download/private-0.1.8.tgz",
+      "resolved": "https://registry.npmjs.org/private/-/private-0.1.8.tgz",
       "integrity": "sha1-I4Hts2ifelPWUxkAYPz4ItLzaP8=",
       "dev": true
     },
     "process": {
       "version": "0.11.10",
-      "resolved": "https://registry.npm.taobao.org/process/download/process-0.11.10.tgz",
+      "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
       "integrity": "sha1-czIwDoQBYb2j5podHZGn1LwW8YI=",
       "dev": true
     },
     "process-nextick-args": {
       "version": "2.0.1",
-      "resolved": "https://registry.npm.taobao.org/process-nextick-args/download/process-nextick-args-2.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
       "integrity": "sha1-eCDZsWEgzFXKmud5JoCufbptf+I=",
       "dev": true
     },
     "progress": {
       "version": "2.0.3",
-      "resolved": "https://registry.npm.taobao.org/progress/download/progress-2.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
       "integrity": "sha1-foz42PW48jnBvGi+tOt4Vn1XLvg=",
       "dev": true
     },
     "promise-inflight": {
       "version": "1.0.1",
-      "resolved": "https://registry.npm.taobao.org/promise-inflight/download/promise-inflight-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/promise-inflight/-/promise-inflight-1.0.1.tgz",
       "integrity": "sha1-mEcocL8igTL8vdhoEputEsPAKeM=",
       "dev": true
     },
     "proxy-addr": {
       "version": "2.0.5",
-      "resolved": "https://registry.npm.taobao.org/proxy-addr/download/proxy-addr-2.0.5.tgz",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.5.tgz",
       "integrity": "sha1-NMvWSi2B9LH9IedvnwbIpFKZ7jQ=",
       "dev": true,
       "requires": {
@@ -8727,25 +8727,25 @@
     },
     "prr": {
       "version": "1.0.1",
-      "resolved": "https://registry.npm.taobao.org/prr/download/prr-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/prr/-/prr-1.0.1.tgz",
       "integrity": "sha1-0/wRS6BplaRexok/SEzrHXj19HY=",
       "dev": true
     },
     "pseudomap": {
       "version": "1.0.2",
-      "resolved": "https://registry.npm.taobao.org/pseudomap/download/pseudomap-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
       "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM=",
       "dev": true
     },
     "psl": {
       "version": "1.3.0",
-      "resolved": "https://registry.npm.taobao.org/psl/download/psl-1.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/psl/-/psl-1.3.0.tgz",
       "integrity": "sha1-4ev2o7VWT6g3bz2iJ12nbYdcob0=",
       "dev": true
     },
     "public-encrypt": {
       "version": "4.0.3",
-      "resolved": "https://registry.npm.taobao.org/public-encrypt/download/public-encrypt-4.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/public-encrypt/-/public-encrypt-4.0.3.tgz",
       "integrity": "sha1-T8ydd6B+SLp1J+fL4N4z0HATMeA=",
       "dev": true,
       "requires": {
@@ -8759,7 +8759,7 @@
     },
     "pump": {
       "version": "3.0.0",
-      "resolved": "https://registry.npm.taobao.org/pump/download/pump-3.0.0.tgz?cache=0&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fpump%2Fdownload%2Fpump-3.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
       "integrity": "sha1-tKIRaBW94vTh6mAjVOjHVWUQemQ=",
       "dev": true,
       "requires": {
@@ -8769,7 +8769,7 @@
     },
     "pumpify": {
       "version": "1.5.1",
-      "resolved": "https://registry.npm.taobao.org/pumpify/download/pumpify-1.5.1.tgz",
+      "resolved": "https://registry.npmjs.org/pumpify/-/pumpify-1.5.1.tgz",
       "integrity": "sha1-NlE74karJ1cLGjdKXOJ4v9dDcM4=",
       "dev": true,
       "requires": {
@@ -8780,7 +8780,7 @@
       "dependencies": {
         "pump": {
           "version": "2.0.1",
-          "resolved": "https://registry.npm.taobao.org/pump/download/pump-2.0.1.tgz?cache=0&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fpump%2Fdownload%2Fpump-2.0.1.tgz",
+          "resolved": "https://registry.npmjs.org/pump/-/pump-2.0.1.tgz",
           "integrity": "sha1-Ejma3W5M91Jtlzy8i1zi4pCLOQk=",
           "dev": true,
           "requires": {
@@ -8792,25 +8792,25 @@
     },
     "punycode": {
       "version": "2.1.1",
-      "resolved": "https://registry.npm.taobao.org/punycode/download/punycode-2.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
       "integrity": "sha1-tYsBCsQMIsVldhbI0sLALHv0eew=",
       "dev": true
     },
     "q": {
       "version": "1.5.1",
-      "resolved": "https://registry.npm.taobao.org/q/download/q-1.5.1.tgz",
+      "resolved": "https://registry.npmjs.org/q/-/q-1.5.1.tgz",
       "integrity": "sha1-fjL3W0E4EpHQRhHxvxQQmsAGUdc=",
       "dev": true
     },
     "qs": {
       "version": "6.5.2",
-      "resolved": "https://registry.npm.taobao.org/qs/download/qs-6.5.2.tgz",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
       "integrity": "sha1-yzroBuh0BERYTvFUzo7pjUA/PjY=",
       "dev": true
     },
     "query-string": {
       "version": "5.1.1",
-      "resolved": "https://registry.npm.taobao.org/query-string/download/query-string-5.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/query-string/-/query-string-5.1.1.tgz",
       "integrity": "sha1-p4wBK3HBfgXy4/ojGd0zBoLvs8s=",
       "dev": true,
       "requires": {
@@ -8821,25 +8821,25 @@
     },
     "querystring": {
       "version": "0.2.0",
-      "resolved": "https://registry.npm.taobao.org/querystring/download/querystring-0.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz",
       "integrity": "sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA=",
       "dev": true
     },
     "querystring-es3": {
       "version": "0.2.1",
-      "resolved": "https://registry.npm.taobao.org/querystring-es3/download/querystring-es3-0.2.1.tgz",
+      "resolved": "https://registry.npmjs.org/querystring-es3/-/querystring-es3-0.2.1.tgz",
       "integrity": "sha1-nsYfeQSYdXB9aUFFlv2Qek1xHnM=",
       "dev": true
     },
     "querystringify": {
       "version": "2.1.1",
-      "resolved": "https://registry.npm.taobao.org/querystringify/download/querystringify-2.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.1.1.tgz",
       "integrity": "sha1-YOWl/WSn+L+k0qsu1v30yFutFU4=",
       "dev": true
     },
     "randombytes": {
       "version": "2.1.0",
-      "resolved": "https://registry.npm.taobao.org/randombytes/download/randombytes-2.1.0.tgz?cache=0&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Frandombytes%2Fdownload%2Frandombytes-2.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
       "integrity": "sha1-32+ENy8CcNxlzfYpE0mrekc9Tyo=",
       "dev": true,
       "requires": {
@@ -8848,7 +8848,7 @@
     },
     "randomfill": {
       "version": "1.0.4",
-      "resolved": "https://registry.npm.taobao.org/randomfill/download/randomfill-1.0.4.tgz",
+      "resolved": "https://registry.npmjs.org/randomfill/-/randomfill-1.0.4.tgz",
       "integrity": "sha1-ySGW/IarQr6YPxvzF3giSTHWFFg=",
       "dev": true,
       "requires": {
@@ -8858,13 +8858,13 @@
     },
     "range-parser": {
       "version": "1.2.1",
-      "resolved": "https://registry.npm.taobao.org/range-parser/download/range-parser-1.2.1.tgz",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
       "integrity": "sha1-PPNwI9GZ4cJNGlW4SADC8+ZGgDE=",
       "dev": true
     },
     "raw-body": {
       "version": "2.4.0",
-      "resolved": "https://registry.npm.taobao.org/raw-body/download/raw-body-2.4.0.tgz?cache=0&sync_timestamp=1561549041659&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fraw-body%2Fdownload%2Fraw-body-2.4.0.tgz",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.4.0.tgz",
       "integrity": "sha1-oc5vucm8NWylLoklarWQWeE9AzI=",
       "dev": true,
       "requires": {
@@ -8876,7 +8876,7 @@
     },
     "read-pkg": {
       "version": "5.2.0",
-      "resolved": "https://registry.npm.taobao.org/read-pkg/download/read-pkg-5.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-5.2.0.tgz",
       "integrity": "sha1-e/KVQ4yloz5WzTDgU7NO5yUMk8w=",
       "dev": true,
       "requires": {
@@ -8888,7 +8888,7 @@
       "dependencies": {
         "parse-json": {
           "version": "5.0.0",
-          "resolved": "https://registry.npm.taobao.org/parse-json/download/parse-json-5.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.0.0.tgz",
           "integrity": "sha1-c+URTJhtFD76NxLU6iTbmkJm9g8=",
           "dev": true,
           "requires": {
@@ -8902,7 +8902,7 @@
     },
     "readable-stream": {
       "version": "2.3.6",
-      "resolved": "https://registry.npm.taobao.org/readable-stream/download/readable-stream-2.3.6.tgz",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
       "integrity": "sha1-sRwn2IuP8fvgcGQ8+UsMea4bCq8=",
       "dev": true,
       "requires": {
@@ -8917,7 +8917,7 @@
     },
     "readdirp": {
       "version": "2.2.1",
-      "resolved": "https://registry.npm.taobao.org/readdirp/download/readdirp-2.2.1.tgz",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-2.2.1.tgz",
       "integrity": "sha1-DodiKjMlqjPokihcr4tOhGUppSU=",
       "dev": true,
       "requires": {
@@ -8928,13 +8928,13 @@
     },
     "regenerate": {
       "version": "1.4.0",
-      "resolved": "https://registry.npm.taobao.org/regenerate/download/regenerate-1.4.0.tgz",
+      "resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.4.0.tgz",
       "integrity": "sha1-SoVuxLVuQHfFV1icroXnpMiGmhE=",
       "dev": true
     },
     "regenerate-unicode-properties": {
       "version": "8.1.0",
-      "resolved": "https://registry.npm.taobao.org/regenerate-unicode-properties/download/regenerate-unicode-properties-8.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/regenerate-unicode-properties/-/regenerate-unicode-properties-8.1.0.tgz",
       "integrity": "sha1-71Hg8OpK1CS3e/fLQfPgFccKPw4=",
       "dev": true,
       "requires": {
@@ -8943,13 +8943,13 @@
     },
     "regenerator-runtime": {
       "version": "0.13.3",
-      "resolved": "https://registry.npm.taobao.org/regenerator-runtime/download/regenerator-runtime-0.13.3.tgz",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.3.tgz",
       "integrity": "sha1-fPanfY9cb2Drc8X8GVWyzrAea/U=",
       "dev": true
     },
     "regenerator-transform": {
       "version": "0.14.1",
-      "resolved": "https://registry.npm.taobao.org/regenerator-transform/download/regenerator-transform-0.14.1.tgz?cache=0&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fregenerator-transform%2Fdownload%2Fregenerator-transform-0.14.1.tgz",
+      "resolved": "https://registry.npmjs.org/regenerator-transform/-/regenerator-transform-0.14.1.tgz",
       "integrity": "sha1-Oy/OThq3cywI9mXf2zFHScfd0vs=",
       "dev": true,
       "requires": {
@@ -8958,7 +8958,7 @@
     },
     "regex-not": {
       "version": "1.0.2",
-      "resolved": "https://registry.npm.taobao.org/regex-not/download/regex-not-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/regex-not/-/regex-not-1.0.2.tgz",
       "integrity": "sha1-H07OJ+ALC2XgJHpoEOaoXYOldSw=",
       "dev": true,
       "requires": {
@@ -8968,20 +8968,20 @@
     },
     "regexp-tree": {
       "version": "0.1.11",
-      "resolved": "https://registry.npm.taobao.org/regexp-tree/download/regexp-tree-0.1.11.tgz?cache=0&sync_timestamp=1562396842997&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fregexp-tree%2Fdownload%2Fregexp-tree-0.1.11.tgz",
+      "resolved": "https://registry.npmjs.org/regexp-tree/-/regexp-tree-0.1.11.tgz",
       "integrity": "sha1-ycfwD89yLgpWxzkJg6emPdbCcvM=",
       "dev": true
     },
     "regexpp": {
       "version": "1.1.0",
-      "resolved": "https://registry.npm.taobao.org/regexpp/download/regexpp-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-1.1.0.tgz",
       "integrity": "sha1-DjUW3Qt5BPQT0tQZPc5GGMOmias=",
       "dev": true,
       "optional": true
     },
     "regexpu-core": {
       "version": "4.5.5",
-      "resolved": "https://registry.npm.taobao.org/regexpu-core/download/regexpu-core-4.5.5.tgz?cache=0&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fregexpu-core%2Fdownload%2Fregexpu-core-4.5.5.tgz",
+      "resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-4.5.5.tgz",
       "integrity": "sha1-qv/mHCr1gmmz5Ra2GnN5A3YyZBE=",
       "dev": true,
       "requires": {
@@ -8995,13 +8995,13 @@
     },
     "regjsgen": {
       "version": "0.5.0",
-      "resolved": "https://registry.npm.taobao.org/regjsgen/download/regjsgen-0.5.0.tgz",
+      "resolved": "https://registry.npmjs.org/regjsgen/-/regjsgen-0.5.0.tgz",
       "integrity": "sha1-p2NNwI+JIJwgSa3aNSVxH7lyZd0=",
       "dev": true
     },
     "regjsparser": {
       "version": "0.6.0",
-      "resolved": "https://registry.npm.taobao.org/regjsparser/download/regjsparser-0.6.0.tgz",
+      "resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.6.0.tgz",
       "integrity": "sha1-8eaui32iuulsmTmbhozWyTOiupw=",
       "dev": true,
       "requires": {
@@ -9010,7 +9010,7 @@
       "dependencies": {
         "jsesc": {
           "version": "0.5.0",
-          "resolved": "https://registry.npm.taobao.org/jsesc/download/jsesc-0.5.0.tgz",
+          "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz",
           "integrity": "sha1-597mbjXW/Bb3EP6R1c9p9w8IkR0=",
           "dev": true
         }
@@ -9018,19 +9018,19 @@
     },
     "relateurl": {
       "version": "0.2.7",
-      "resolved": "https://registry.npm.taobao.org/relateurl/download/relateurl-0.2.7.tgz",
+      "resolved": "https://registry.npmjs.org/relateurl/-/relateurl-0.2.7.tgz",
       "integrity": "sha1-VNvzd+UUQKypCkzSdGANP/LYiKk=",
       "dev": true
     },
     "remove-trailing-separator": {
       "version": "1.1.0",
-      "resolved": "https://registry.npm.taobao.org/remove-trailing-separator/download/remove-trailing-separator-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz",
       "integrity": "sha1-wkvOKig62tW8P1jg1IJJuSN52O8=",
       "dev": true
     },
     "renderkid": {
       "version": "2.0.3",
-      "resolved": "https://registry.npm.taobao.org/renderkid/download/renderkid-2.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/renderkid/-/renderkid-2.0.3.tgz",
       "integrity": "sha1-OAF5wv9a4TZcUivy/Pz/AcW3QUk=",
       "dev": true,
       "requires": {
@@ -9043,13 +9043,13 @@
       "dependencies": {
         "ansi-regex": {
           "version": "2.1.1",
-          "resolved": "https://registry.npm.taobao.org/ansi-regex/download/ansi-regex-2.1.1.tgz",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
           "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
           "dev": true
         },
         "css-select": {
           "version": "1.2.0",
-          "resolved": "https://registry.npm.taobao.org/css-select/download/css-select-1.2.0.tgz",
+          "resolved": "https://registry.npmjs.org/css-select/-/css-select-1.2.0.tgz",
           "integrity": "sha1-KzoRBTnFNV8c2NMUYj6HCxIeyFg=",
           "dev": true,
           "requires": {
@@ -9061,7 +9061,7 @@
         },
         "domutils": {
           "version": "1.5.1",
-          "resolved": "https://registry.npm.taobao.org/domutils/download/domutils-1.5.1.tgz",
+          "resolved": "https://registry.npmjs.org/domutils/-/domutils-1.5.1.tgz",
           "integrity": "sha1-3NhIiib1Y9YQeeSMn3t+Mjc2gs8=",
           "dev": true,
           "requires": {
@@ -9071,7 +9071,7 @@
         },
         "strip-ansi": {
           "version": "3.0.1",
-          "resolved": "https://registry.npm.taobao.org/strip-ansi/download/strip-ansi-3.0.1.tgz",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "dev": true,
           "requires": {
@@ -9082,19 +9082,19 @@
     },
     "repeat-element": {
       "version": "1.1.3",
-      "resolved": "https://registry.npm.taobao.org/repeat-element/download/repeat-element-1.1.3.tgz",
+      "resolved": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.3.tgz",
       "integrity": "sha1-eC4NglwMWjuzlzH4Tv7mt0Lmsc4=",
       "dev": true
     },
     "repeat-string": {
       "version": "1.6.1",
-      "resolved": "https://registry.npm.taobao.org/repeat-string/download/repeat-string-1.6.1.tgz",
+      "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
       "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc=",
       "dev": true
     },
     "request": {
       "version": "2.88.0",
-      "resolved": "https://registry.npm.taobao.org/request/download/request-2.88.0.tgz",
+      "resolved": "https://registry.npmjs.org/request/-/request-2.88.0.tgz",
       "integrity": "sha1-nC/KT301tZLv5Xx/ClXoEFIST+8=",
       "dev": true,
       "requires": {
@@ -9122,7 +9122,7 @@
     },
     "request-promise-core": {
       "version": "1.1.2",
-      "resolved": "https://registry.npm.taobao.org/request-promise-core/download/request-promise-core-1.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/request-promise-core/-/request-promise-core-1.1.2.tgz",
       "integrity": "sha1-M59qq6vK/bMceZ/xWHADNjAdM0Y=",
       "dev": true,
       "requires": {
@@ -9131,7 +9131,7 @@
     },
     "request-promise-native": {
       "version": "1.0.7",
-      "resolved": "https://registry.npm.taobao.org/request-promise-native/download/request-promise-native-1.0.7.tgz",
+      "resolved": "https://registry.npmjs.org/request-promise-native/-/request-promise-native-1.0.7.tgz",
       "integrity": "sha1-pJhopiS96lBp8SUdCoNuDYmqLFk=",
       "dev": true,
       "requires": {
@@ -9142,19 +9142,19 @@
     },
     "require-directory": {
       "version": "2.1.1",
-      "resolved": "https://registry.npm.taobao.org/require-directory/download/require-directory-2.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
       "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
       "dev": true
     },
     "require-main-filename": {
       "version": "2.0.0",
-      "resolved": "https://registry.npm.taobao.org/require-main-filename/download/require-main-filename-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
       "integrity": "sha1-0LMp7MfMD2Fkn2IhW+aa9UqomJs=",
       "dev": true
     },
     "require-uncached": {
       "version": "1.0.3",
-      "resolved": "https://registry.npm.taobao.org/require-uncached/download/require-uncached-1.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/require-uncached/-/require-uncached-1.0.3.tgz",
       "integrity": "sha1-Tg1W1slmL9MeQwEcS5WqSZVUIdM=",
       "dev": true,
       "optional": true,
@@ -9165,19 +9165,19 @@
     },
     "requires-port": {
       "version": "1.0.0",
-      "resolved": "https://registry.npm.taobao.org/requires-port/download/requires-port-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
       "integrity": "sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8=",
       "dev": true
     },
     "reselect": {
       "version": "3.0.1",
-      "resolved": "https://registry.npm.taobao.org/reselect/download/reselect-3.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/reselect/-/reselect-3.0.1.tgz",
       "integrity": "sha1-79qpjqdFEyTQkrKyFjpqHXqaIUc=",
       "dev": true
     },
     "resolve": {
       "version": "1.12.0",
-      "resolved": "https://registry.npm.taobao.org/resolve/download/resolve-1.12.0.tgz?cache=0&sync_timestamp=1564641434608&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fresolve%2Fdownload%2Fresolve-1.12.0.tgz",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.12.0.tgz",
       "integrity": "sha1-P8ZEo1yEpIVUYJ/ybsUrZvpXffY=",
       "dev": true,
       "requires": {
@@ -9186,7 +9186,7 @@
     },
     "resolve-cwd": {
       "version": "2.0.0",
-      "resolved": "https://registry.npm.taobao.org/resolve-cwd/download/resolve-cwd-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/resolve-cwd/-/resolve-cwd-2.0.0.tgz",
       "integrity": "sha1-AKn3OHVW4nA46uIyyqNypqWbZlo=",
       "dev": true,
       "requires": {
@@ -9195,7 +9195,7 @@
       "dependencies": {
         "resolve-from": {
           "version": "3.0.0",
-          "resolved": "https://registry.npm.taobao.org/resolve-from/download/resolve-from-3.0.0.tgz?cache=0&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fresolve-from%2Fdownload%2Fresolve-from-3.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-3.0.0.tgz",
           "integrity": "sha1-six699nWiBvItuZTM17rywoYh0g=",
           "dev": true
         }
@@ -9203,20 +9203,20 @@
     },
     "resolve-from": {
       "version": "1.0.1",
-      "resolved": "https://registry.npm.taobao.org/resolve-from/download/resolve-from-1.0.1.tgz?cache=0&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fresolve-from%2Fdownload%2Fresolve-from-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-1.0.1.tgz",
       "integrity": "sha1-Jsv+k10a7uq7Kbw/5a6wHpPUQiY=",
       "dev": true,
       "optional": true
     },
     "resolve-url": {
       "version": "0.2.1",
-      "resolved": "https://registry.npm.taobao.org/resolve-url/download/resolve-url-0.2.1.tgz",
+      "resolved": "https://registry.npmjs.org/resolve-url/-/resolve-url-0.2.1.tgz",
       "integrity": "sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo=",
       "dev": true
     },
     "restore-cursor": {
       "version": "2.0.0",
-      "resolved": "https://registry.npm.taobao.org/restore-cursor/download/restore-cursor-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-2.0.0.tgz",
       "integrity": "sha1-n37ih/gv0ybU/RYpI9YhKe7g368=",
       "dev": true,
       "requires": {
@@ -9226,31 +9226,31 @@
     },
     "ret": {
       "version": "0.1.15",
-      "resolved": "https://registry.npm.taobao.org/ret/download/ret-0.1.15.tgz",
+      "resolved": "https://registry.npmjs.org/ret/-/ret-0.1.15.tgz",
       "integrity": "sha1-uKSCXVvbH8P29Twrwz+BOIaBx7w=",
       "dev": true
     },
     "retry": {
       "version": "0.12.0",
-      "resolved": "https://registry.npm.taobao.org/retry/download/retry-0.12.0.tgz",
+      "resolved": "https://registry.npmjs.org/retry/-/retry-0.12.0.tgz",
       "integrity": "sha1-G0KmJmoh8HQh0bC1S33BZ7AcATs=",
       "dev": true
     },
     "rgb-regex": {
       "version": "1.0.1",
-      "resolved": "https://registry.npm.taobao.org/rgb-regex/download/rgb-regex-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/rgb-regex/-/rgb-regex-1.0.1.tgz",
       "integrity": "sha1-wODWiC3w4jviVKR16O3UGRX+rrE=",
       "dev": true
     },
     "rgba-regex": {
       "version": "1.0.0",
-      "resolved": "https://registry.npm.taobao.org/rgba-regex/download/rgba-regex-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/rgba-regex/-/rgba-regex-1.0.0.tgz",
       "integrity": "sha1-QzdOLiyglosO8VI0YLfXMP8i7rM=",
       "dev": true
     },
     "rimraf": {
       "version": "2.6.3",
-      "resolved": "https://registry.npm.taobao.org/rimraf/download/rimraf-2.6.3.tgz",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
       "integrity": "sha1-stEE/g2Psnz54KHNqCYt04M8bKs=",
       "dev": true,
       "requires": {
@@ -9259,7 +9259,7 @@
     },
     "ripemd160": {
       "version": "2.0.2",
-      "resolved": "https://registry.npm.taobao.org/ripemd160/download/ripemd160-2.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/ripemd160/-/ripemd160-2.0.2.tgz",
       "integrity": "sha1-ocGm9iR1FXe6XQeRTLyShQWFiQw=",
       "dev": true,
       "requires": {
@@ -9269,7 +9269,7 @@
     },
     "run-async": {
       "version": "2.3.0",
-      "resolved": "https://registry.npm.taobao.org/run-async/download/run-async-2.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/run-async/-/run-async-2.3.0.tgz",
       "integrity": "sha1-A3GrSuC91yDUFm19/aZP96RFpsA=",
       "dev": true,
       "requires": {
@@ -9278,7 +9278,7 @@
     },
     "run-queue": {
       "version": "1.0.3",
-      "resolved": "https://registry.npm.taobao.org/run-queue/download/run-queue-1.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/run-queue/-/run-queue-1.0.3.tgz",
       "integrity": "sha1-6Eg5bwV9Ij8kOGkkYY4laUFh7Ec=",
       "dev": true,
       "requires": {
@@ -9287,13 +9287,13 @@
     },
     "rx-lite": {
       "version": "4.0.8",
-      "resolved": "https://registry.npm.taobao.org/rx-lite/download/rx-lite-4.0.8.tgz",
+      "resolved": "https://registry.npmjs.org/rx-lite/-/rx-lite-4.0.8.tgz",
       "integrity": "sha1-Cx4Rr4vESDbwSmQH6S2kJGe3lEQ=",
       "dev": true
     },
     "rx-lite-aggregates": {
       "version": "4.0.8",
-      "resolved": "https://registry.npm.taobao.org/rx-lite-aggregates/download/rx-lite-aggregates-4.0.8.tgz",
+      "resolved": "https://registry.npmjs.org/rx-lite-aggregates/-/rx-lite-aggregates-4.0.8.tgz",
       "integrity": "sha1-dTuHqJoRyVRnxKwWJsTvxOBcZ74=",
       "dev": true,
       "optional": true,
@@ -9303,7 +9303,7 @@
     },
     "rxjs": {
       "version": "6.5.2",
-      "resolved": "https://registry.npm.taobao.org/rxjs/download/rxjs-6.5.2.tgz",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.5.2.tgz",
       "integrity": "sha1-LjXOgVzUbYTQKiCftOWSHgUdvsc=",
       "dev": true,
       "requires": {
@@ -9312,13 +9312,13 @@
     },
     "safe-buffer": {
       "version": "5.1.2",
-      "resolved": "https://registry.npm.taobao.org/safe-buffer/download/safe-buffer-5.1.2.tgz?cache=0&sync_timestamp=1562350533022&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fsafe-buffer%2Fdownload%2Fsafe-buffer-5.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
       "integrity": "sha1-mR7GnSluAxN0fVm9/St0XDX4go0=",
       "dev": true
     },
     "safe-regex": {
       "version": "1.1.0",
-      "resolved": "https://registry.npm.taobao.org/safe-regex/download/safe-regex-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/safe-regex/-/safe-regex-1.1.0.tgz",
       "integrity": "sha1-QKNmnzsHfR6UPURinhV91IAjvy4=",
       "dev": true,
       "requires": {
@@ -9327,13 +9327,13 @@
     },
     "safer-buffer": {
       "version": "2.1.2",
-      "resolved": "https://registry.npm.taobao.org/safer-buffer/download/safer-buffer-2.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha1-RPoWGwGHuVSd2Eu5GAL5vYOFzWo=",
       "dev": true
     },
     "sass": {
       "version": "1.22.9",
-      "resolved": "https://registry.npm.taobao.org/sass/download/sass-1.22.9.tgz",
+      "resolved": "https://registry.npmjs.org/sass/-/sass-1.22.9.tgz",
       "integrity": "sha1-QaLtYDgCf1i+K9UEEpNFKinCy4Q=",
       "dev": true,
       "requires": {
@@ -9342,7 +9342,7 @@
     },
     "sass-loader": {
       "version": "7.2.0",
-      "resolved": "https://registry.npm.taobao.org/sass-loader/download/sass-loader-7.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/sass-loader/-/sass-loader-7.2.0.tgz",
       "integrity": "sha1-40EVI5MJ0VslJ8titd/vtiqW/38=",
       "dev": true,
       "requires": {
@@ -9355,13 +9355,13 @@
     },
     "sax": {
       "version": "1.2.4",
-      "resolved": "https://registry.npm.taobao.org/sax/download/sax-1.2.4.tgz",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
       "integrity": "sha1-KBYjTiN4vdxOU1T6tcqold9xANk=",
       "dev": true
     },
     "schema-utils": {
       "version": "0.4.7",
-      "resolved": "https://registry.npm.taobao.org/schema-utils/download/schema-utils-0.4.7.tgz?cache=0&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fschema-utils%2Fdownload%2Fschema-utils-0.4.7.tgz",
+      "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-0.4.7.tgz",
       "integrity": "sha1-unT1l9K+LqiAExdG7hfQoJPGgYc=",
       "dev": true,
       "requires": {
@@ -9371,13 +9371,13 @@
     },
     "select-hose": {
       "version": "2.0.0",
-      "resolved": "https://registry.npm.taobao.org/select-hose/download/select-hose-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/select-hose/-/select-hose-2.0.0.tgz",
       "integrity": "sha1-Yl2GWPhlr0Psliv8N2o3NZpJlMo=",
       "dev": true
     },
     "selfsigned": {
       "version": "1.10.4",
-      "resolved": "https://registry.npm.taobao.org/selfsigned/download/selfsigned-1.10.4.tgz",
+      "resolved": "https://registry.npmjs.org/selfsigned/-/selfsigned-1.10.4.tgz",
       "integrity": "sha1-zdfsz8pO12NdR6CL8tXTB0CS4s0=",
       "dev": true,
       "requires": {
@@ -9386,13 +9386,13 @@
     },
     "semver": {
       "version": "5.7.0",
-      "resolved": "https://registry.npm.taobao.org/semver/download/semver-5.7.0.tgz",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
       "integrity": "sha1-eQp89v6lRZuslhELKbYEEtyP+Ws=",
       "dev": true
     },
     "send": {
       "version": "0.17.1",
-      "resolved": "https://registry.npm.taobao.org/send/download/send-0.17.1.tgz",
+      "resolved": "https://registry.npmjs.org/send/-/send-0.17.1.tgz",
       "integrity": "sha1-wdiwWfeQD3Rm3Uk4vcROEd2zdsg=",
       "dev": true,
       "requires": {
@@ -9413,7 +9413,7 @@
       "dependencies": {
         "debug": {
           "version": "2.6.9",
-          "resolved": "https://registry.npm.taobao.org/debug/download/debug-2.6.9.tgz",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
           "integrity": "sha1-XRKFFd8TT/Mn6QpMk/Tgd6U2NB8=",
           "dev": true,
           "requires": {
@@ -9422,7 +9422,7 @@
           "dependencies": {
             "ms": {
               "version": "2.0.0",
-              "resolved": "https://registry.npm.taobao.org/ms/download/ms-2.0.0.tgz?cache=0&sync_timestamp=1559842528856&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fms%2Fdownload%2Fms-2.0.0.tgz",
+              "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
               "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
               "dev": true
             }
@@ -9430,13 +9430,13 @@
         },
         "mime": {
           "version": "1.6.0",
-          "resolved": "https://registry.npm.taobao.org/mime/download/mime-1.6.0.tgz",
+          "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
           "integrity": "sha1-Ms2eXGRVO9WNGaVor0Uqz/BJgbE=",
           "dev": true
         },
         "ms": {
           "version": "2.1.1",
-          "resolved": "https://registry.npm.taobao.org/ms/download/ms-2.1.1.tgz?cache=0&sync_timestamp=1559842528856&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fms%2Fdownload%2Fms-2.1.1.tgz",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
           "integrity": "sha1-MKWGTrPrsKZvLr5tcnrwagnYbgo=",
           "dev": true
         }
@@ -9444,13 +9444,13 @@
     },
     "serialize-javascript": {
       "version": "1.7.0",
-      "resolved": "https://registry.npm.taobao.org/serialize-javascript/download/serialize-javascript-1.7.0.tgz",
+      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-1.7.0.tgz",
       "integrity": "sha1-1uDfsqODKoyURo5usduX5VoZKmU=",
       "dev": true
     },
     "serve-index": {
       "version": "1.9.1",
-      "resolved": "https://registry.npm.taobao.org/serve-index/download/serve-index-1.9.1.tgz",
+      "resolved": "https://registry.npmjs.org/serve-index/-/serve-index-1.9.1.tgz",
       "integrity": "sha1-03aNabHn2C5c4FD/9bRTvqEqkjk=",
       "dev": true,
       "requires": {
@@ -9465,7 +9465,7 @@
       "dependencies": {
         "debug": {
           "version": "2.6.9",
-          "resolved": "https://registry.npm.taobao.org/debug/download/debug-2.6.9.tgz",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
           "integrity": "sha1-XRKFFd8TT/Mn6QpMk/Tgd6U2NB8=",
           "dev": true,
           "requires": {
@@ -9474,7 +9474,7 @@
         },
         "http-errors": {
           "version": "1.6.3",
-          "resolved": "https://registry.npm.taobao.org/http-errors/download/http-errors-1.6.3.tgz",
+          "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.3.tgz",
           "integrity": "sha1-i1VoC7S+KDoLW/TqLjhYC+HZMg0=",
           "dev": true,
           "requires": {
@@ -9486,19 +9486,19 @@
         },
         "inherits": {
           "version": "2.0.3",
-          "resolved": "https://registry.npm.taobao.org/inherits/download/inherits-2.0.3.tgz?cache=0&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Finherits%2Fdownload%2Finherits-2.0.3.tgz",
+          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
           "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
           "dev": true
         },
         "ms": {
           "version": "2.0.0",
-          "resolved": "https://registry.npm.taobao.org/ms/download/ms-2.0.0.tgz?cache=0&sync_timestamp=1559842528856&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fms%2Fdownload%2Fms-2.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
           "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
           "dev": true
         },
         "setprototypeof": {
           "version": "1.1.0",
-          "resolved": "https://registry.npm.taobao.org/setprototypeof/download/setprototypeof-1.1.0.tgz",
+          "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.0.tgz",
           "integrity": "sha1-0L2FU2iHtv58DYGMuWLZ2RxU5lY=",
           "dev": true
         }
@@ -9506,7 +9506,7 @@
     },
     "serve-static": {
       "version": "1.14.1",
-      "resolved": "https://registry.npm.taobao.org/serve-static/download/serve-static-1.14.1.tgz",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.14.1.tgz",
       "integrity": "sha1-Zm5jbcTwEPfvKZcKiKZ0MgiYsvk=",
       "dev": true,
       "requires": {
@@ -9518,13 +9518,13 @@
     },
     "set-blocking": {
       "version": "2.0.0",
-      "resolved": "https://registry.npm.taobao.org/set-blocking/download/set-blocking-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
       "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
       "dev": true
     },
     "set-value": {
       "version": "2.0.1",
-      "resolved": "https://registry.npm.taobao.org/set-value/download/set-value-2.0.1.tgz?cache=0&sync_timestamp=1561410560353&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fset-value%2Fdownload%2Fset-value-2.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/set-value/-/set-value-2.0.1.tgz",
       "integrity": "sha1-oY1AUw5vB95CKMfe/kInr4ytAFs=",
       "dev": true,
       "requires": {
@@ -9536,7 +9536,7 @@
       "dependencies": {
         "extend-shallow": {
           "version": "2.0.1",
-          "resolved": "https://registry.npm.taobao.org/extend-shallow/download/extend-shallow-2.0.1.tgz",
+          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
           "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
           "dev": true,
           "requires": {
@@ -9547,19 +9547,19 @@
     },
     "setimmediate": {
       "version": "1.0.5",
-      "resolved": "https://registry.npm.taobao.org/setimmediate/download/setimmediate-1.0.5.tgz",
+      "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
       "integrity": "sha1-KQy7Iy4waULX1+qbg3Mqt4VvgoU=",
       "dev": true
     },
     "setprototypeof": {
       "version": "1.1.1",
-      "resolved": "https://registry.npm.taobao.org/setprototypeof/download/setprototypeof-1.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.1.tgz",
       "integrity": "sha1-fpWsskqpL1iF4KvvW6ExMw1K5oM=",
       "dev": true
     },
     "sha.js": {
       "version": "2.4.11",
-      "resolved": "https://registry.npm.taobao.org/sha.js/download/sha.js-2.4.11.tgz?cache=0&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fsha.js%2Fdownload%2Fsha.js-2.4.11.tgz",
+      "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.11.tgz",
       "integrity": "sha1-N6XPC4HsvGlD3hCbopYNGyZYSuc=",
       "dev": true,
       "requires": {
@@ -9569,7 +9569,7 @@
     },
     "shallow-clone": {
       "version": "3.0.1",
-      "resolved": "https://registry.npm.taobao.org/shallow-clone/download/shallow-clone-3.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/shallow-clone/-/shallow-clone-3.0.1.tgz",
       "integrity": "sha1-jymBrZJTH1UDWwH7IwdppA4C76M=",
       "dev": true,
       "requires": {
@@ -9578,7 +9578,7 @@
     },
     "shebang-command": {
       "version": "1.2.0",
-      "resolved": "https://registry.npm.taobao.org/shebang-command/download/shebang-command-1.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
       "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
       "dev": true,
       "requires": {
@@ -9587,13 +9587,13 @@
     },
     "shebang-regex": {
       "version": "1.0.0",
-      "resolved": "https://registry.npm.taobao.org/shebang-regex/download/shebang-regex-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
       "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
       "dev": true
     },
     "shell-quote": {
       "version": "1.6.1",
-      "resolved": "https://registry.npm.taobao.org/shell-quote/download/shell-quote-1.6.1.tgz",
+      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.6.1.tgz",
       "integrity": "sha1-9HgZSczkAmlxJ0MOo7PFR29IF2c=",
       "dev": true,
       "requires": {
@@ -9605,13 +9605,13 @@
     },
     "signal-exit": {
       "version": "3.0.2",
-      "resolved": "https://registry.npm.taobao.org/signal-exit/download/signal-exit-3.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
       "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
       "dev": true
     },
     "simple-swizzle": {
       "version": "0.2.2",
-      "resolved": "https://registry.npm.taobao.org/simple-swizzle/download/simple-swizzle-0.2.2.tgz",
+      "resolved": "https://registry.npmjs.org/simple-swizzle/-/simple-swizzle-0.2.2.tgz",
       "integrity": "sha1-pNprY1/8zMoz9w0Xy5JZLeleVXo=",
       "dev": true,
       "requires": {
@@ -9620,7 +9620,7 @@
       "dependencies": {
         "is-arrayish": {
           "version": "0.3.2",
-          "resolved": "https://registry.npm.taobao.org/is-arrayish/download/is-arrayish-0.3.2.tgz",
+          "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.3.2.tgz",
           "integrity": "sha1-RXSirlb3qyBolvtDHq7tBm/fjwM=",
           "dev": true
         }
@@ -9628,13 +9628,13 @@
     },
     "slash": {
       "version": "2.0.0",
-      "resolved": "https://registry.npm.taobao.org/slash/download/slash-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/slash/-/slash-2.0.0.tgz",
       "integrity": "sha1-3lUoUaF1nfOo8gZTVEL17E3eq0Q=",
       "dev": true
     },
     "slice-ansi": {
       "version": "1.0.0",
-      "resolved": "https://registry.npm.taobao.org/slice-ansi/download/slice-ansi-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-1.0.0.tgz",
       "integrity": "sha1-BE8aSdiEL/MHqta1Be0Xi9lQE00=",
       "dev": true,
       "optional": true,
@@ -9644,7 +9644,7 @@
     },
     "snapdragon": {
       "version": "0.8.2",
-      "resolved": "https://registry.npm.taobao.org/snapdragon/download/snapdragon-0.8.2.tgz",
+      "resolved": "https://registry.npmjs.org/snapdragon/-/snapdragon-0.8.2.tgz",
       "integrity": "sha1-ZJIufFZbDhQgS6GqfWlkJ40lGC0=",
       "dev": true,
       "requires": {
@@ -9660,7 +9660,7 @@
       "dependencies": {
         "debug": {
           "version": "2.6.9",
-          "resolved": "https://registry.npm.taobao.org/debug/download/debug-2.6.9.tgz",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
           "integrity": "sha1-XRKFFd8TT/Mn6QpMk/Tgd6U2NB8=",
           "dev": true,
           "requires": {
@@ -9669,7 +9669,7 @@
         },
         "define-property": {
           "version": "0.2.5",
-          "resolved": "https://registry.npm.taobao.org/define-property/download/define-property-0.2.5.tgz",
+          "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
           "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
           "dev": true,
           "requires": {
@@ -9678,7 +9678,7 @@
         },
         "extend-shallow": {
           "version": "2.0.1",
-          "resolved": "https://registry.npm.taobao.org/extend-shallow/download/extend-shallow-2.0.1.tgz",
+          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
           "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
           "dev": true,
           "requires": {
@@ -9687,7 +9687,7 @@
         },
         "ms": {
           "version": "2.0.0",
-          "resolved": "https://registry.npm.taobao.org/ms/download/ms-2.0.0.tgz?cache=0&sync_timestamp=1559842528856&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fms%2Fdownload%2Fms-2.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
           "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
           "dev": true
         }
@@ -9695,7 +9695,7 @@
     },
     "snapdragon-node": {
       "version": "2.1.1",
-      "resolved": "https://registry.npm.taobao.org/snapdragon-node/download/snapdragon-node-2.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/snapdragon-node/-/snapdragon-node-2.1.1.tgz",
       "integrity": "sha1-bBdfhv8UvbByRWPo88GwIaKGhTs=",
       "dev": true,
       "requires": {
@@ -9706,7 +9706,7 @@
       "dependencies": {
         "define-property": {
           "version": "1.0.0",
-          "resolved": "https://registry.npm.taobao.org/define-property/download/define-property-1.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
           "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
           "dev": true,
           "requires": {
@@ -9715,7 +9715,7 @@
         },
         "is-accessor-descriptor": {
           "version": "1.0.0",
-          "resolved": "https://registry.npm.taobao.org/is-accessor-descriptor/download/is-accessor-descriptor-1.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
           "integrity": "sha1-FpwvbT3x+ZJhgHI2XJsOofaHhlY=",
           "dev": true,
           "requires": {
@@ -9724,7 +9724,7 @@
         },
         "is-data-descriptor": {
           "version": "1.0.0",
-          "resolved": "https://registry.npm.taobao.org/is-data-descriptor/download/is-data-descriptor-1.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
           "integrity": "sha1-2Eh2Mh0Oet0DmQQGq7u9NrqSaMc=",
           "dev": true,
           "requires": {
@@ -9733,7 +9733,7 @@
         },
         "is-descriptor": {
           "version": "1.0.2",
-          "resolved": "https://registry.npm.taobao.org/is-descriptor/download/is-descriptor-1.0.2.tgz",
+          "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
           "integrity": "sha1-OxWXRqZmBLBPjIFSS6NlxfFNhuw=",
           "dev": true,
           "requires": {
@@ -9746,7 +9746,7 @@
     },
     "snapdragon-util": {
       "version": "3.0.1",
-      "resolved": "https://registry.npm.taobao.org/snapdragon-util/download/snapdragon-util-3.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/snapdragon-util/-/snapdragon-util-3.0.1.tgz",
       "integrity": "sha1-+VZHlIbyrNeXAGk/b3uAXkWrVuI=",
       "dev": true,
       "requires": {
@@ -9755,7 +9755,7 @@
       "dependencies": {
         "kind-of": {
           "version": "3.2.2",
-          "resolved": "https://registry.npm.taobao.org/kind-of/download/kind-of-3.2.2.tgz",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
           "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
           "dev": true,
           "requires": {
@@ -9766,7 +9766,7 @@
     },
     "sockjs": {
       "version": "0.3.19",
-      "resolved": "https://registry.npm.taobao.org/sockjs/download/sockjs-0.3.19.tgz",
+      "resolved": "https://registry.npmjs.org/sockjs/-/sockjs-0.3.19.tgz",
       "integrity": "sha1-2Xa76ACve9IK4IWY1YI5NQiZPA0=",
       "dev": true,
       "requires": {
@@ -9776,7 +9776,7 @@
     },
     "sockjs-client": {
       "version": "1.3.0",
-      "resolved": "https://registry.npm.taobao.org/sockjs-client/download/sockjs-client-1.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/sockjs-client/-/sockjs-client-1.3.0.tgz",
       "integrity": "sha1-EvydbLZj2lc509xftuhofalcsXc=",
       "dev": true,
       "requires": {
@@ -9790,7 +9790,7 @@
       "dependencies": {
         "debug": {
           "version": "3.2.6",
-          "resolved": "https://registry.npm.taobao.org/debug/download/debug-3.2.6.tgz",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
           "integrity": "sha1-6D0X3hbYp++3cX7b5fsQE17uYps=",
           "dev": true,
           "requires": {
@@ -9799,7 +9799,7 @@
         },
         "faye-websocket": {
           "version": "0.11.3",
-          "resolved": "https://registry.npm.taobao.org/faye-websocket/download/faye-websocket-0.11.3.tgz",
+          "resolved": "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.11.3.tgz",
           "integrity": "sha1-XA6aiWjokSwoZjn96XeosgnyUI4=",
           "dev": true,
           "requires": {
@@ -9810,7 +9810,7 @@
     },
     "sort-keys": {
       "version": "2.0.0",
-      "resolved": "https://registry.npm.taobao.org/sort-keys/download/sort-keys-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/sort-keys/-/sort-keys-2.0.0.tgz",
       "integrity": "sha1-ZYU1WEhh7JfXMNbPQYIuH1ZoQSg=",
       "dev": true,
       "requires": {
@@ -9819,19 +9819,19 @@
     },
     "source-list-map": {
       "version": "2.0.1",
-      "resolved": "https://registry.npm.taobao.org/source-list-map/download/source-list-map-2.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/source-list-map/-/source-list-map-2.0.1.tgz",
       "integrity": "sha1-OZO9hzv8SEecyp6jpUeDXHwVSzQ=",
       "dev": true
     },
     "source-map": {
       "version": "0.5.7",
-      "resolved": "https://registry.npm.taobao.org/source-map/download/source-map-0.5.7.tgz",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
       "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
       "dev": true
     },
     "source-map-resolve": {
       "version": "0.5.2",
-      "resolved": "https://registry.npm.taobao.org/source-map-resolve/download/source-map-resolve-0.5.2.tgz",
+      "resolved": "https://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.5.2.tgz",
       "integrity": "sha1-cuLMNAlVQ+Q7LGKyxMENSpBU8lk=",
       "dev": true,
       "requires": {
@@ -9844,7 +9844,7 @@
     },
     "source-map-support": {
       "version": "0.5.13",
-      "resolved": "https://registry.npm.taobao.org/source-map-support/download/source-map-support-0.5.13.tgz",
+      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.13.tgz",
       "integrity": "sha1-MbJKnC5zwt6FBmwP631Edn7VKTI=",
       "dev": true,
       "requires": {
@@ -9854,7 +9854,7 @@
       "dependencies": {
         "source-map": {
           "version": "0.6.1",
-          "resolved": "https://registry.npm.taobao.org/source-map/download/source-map-0.6.1.tgz",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
           "integrity": "sha1-dHIq8y6WFOnCh6jQu95IteLxomM=",
           "dev": true
         }
@@ -9862,13 +9862,13 @@
     },
     "source-map-url": {
       "version": "0.4.0",
-      "resolved": "https://registry.npm.taobao.org/source-map-url/download/source-map-url-0.4.0.tgz",
+      "resolved": "https://registry.npmjs.org/source-map-url/-/source-map-url-0.4.0.tgz",
       "integrity": "sha1-PpNdfd1zYxuXZZlW1VEo6HtQhKM=",
       "dev": true
     },
     "spdx-correct": {
       "version": "3.1.0",
-      "resolved": "https://registry.npm.taobao.org/spdx-correct/download/spdx-correct-3.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.1.0.tgz",
       "integrity": "sha1-+4PlBERSaPFUsHTiGMh8ADzTHfQ=",
       "dev": true,
       "requires": {
@@ -9878,13 +9878,13 @@
     },
     "spdx-exceptions": {
       "version": "2.2.0",
-      "resolved": "https://registry.npm.taobao.org/spdx-exceptions/download/spdx-exceptions-2.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.2.0.tgz",
       "integrity": "sha1-LqRQrudPKom/uUUZwH/Nb0EyKXc=",
       "dev": true
     },
     "spdx-expression-parse": {
       "version": "3.0.0",
-      "resolved": "https://registry.npm.taobao.org/spdx-expression-parse/download/spdx-expression-parse-3.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.0.tgz",
       "integrity": "sha1-meEZt6XaAOBUkcn6M4t5BII7QdA=",
       "dev": true,
       "requires": {
@@ -9894,13 +9894,13 @@
     },
     "spdx-license-ids": {
       "version": "3.0.5",
-      "resolved": "https://registry.npm.taobao.org/spdx-license-ids/download/spdx-license-ids-3.0.5.tgz",
+      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.5.tgz",
       "integrity": "sha1-NpS1gEVnpFjTyARYQqY1hjL2JlQ=",
       "dev": true
     },
     "spdy": {
       "version": "4.0.1",
-      "resolved": "https://registry.npm.taobao.org/spdy/download/spdy-4.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/spdy/-/spdy-4.0.1.tgz",
       "integrity": "sha1-bxLtHF236k8k67i4m6WMh8CCV/I=",
       "dev": true,
       "requires": {
@@ -9913,7 +9913,7 @@
     },
     "spdy-transport": {
       "version": "3.0.0",
-      "resolved": "https://registry.npm.taobao.org/spdy-transport/download/spdy-transport-3.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/spdy-transport/-/spdy-transport-3.0.0.tgz",
       "integrity": "sha1-ANSGOmQArXXfkzYaFghgXl3NzzE=",
       "dev": true,
       "requires": {
@@ -9927,7 +9927,7 @@
       "dependencies": {
         "readable-stream": {
           "version": "3.4.0",
-          "resolved": "https://registry.npm.taobao.org/readable-stream/download/readable-stream-3.4.0.tgz",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.4.0.tgz",
           "integrity": "sha1-pRwmdUZY4KPCHb9ZFjvUW6b0R/w=",
           "dev": true,
           "requires": {
@@ -9940,7 +9940,7 @@
     },
     "split-string": {
       "version": "3.1.0",
-      "resolved": "https://registry.npm.taobao.org/split-string/download/split-string-3.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/split-string/-/split-string-3.1.0.tgz",
       "integrity": "sha1-fLCd2jqGWFcFxks5pkZgOGguj+I=",
       "dev": true,
       "requires": {
@@ -9949,13 +9949,13 @@
     },
     "sprintf-js": {
       "version": "1.0.3",
-      "resolved": "https://registry.npm.taobao.org/sprintf-js/download/sprintf-js-1.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
       "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
       "dev": true
     },
     "sshpk": {
       "version": "1.16.1",
-      "resolved": "https://registry.npm.taobao.org/sshpk/download/sshpk-1.16.1.tgz",
+      "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.16.1.tgz",
       "integrity": "sha1-+2YcC+8ps520B2nuOfpwCT1vaHc=",
       "dev": true,
       "requires": {
@@ -9972,7 +9972,7 @@
     },
     "ssri": {
       "version": "6.0.1",
-      "resolved": "https://registry.npm.taobao.org/ssri/download/ssri-6.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/ssri/-/ssri-6.0.1.tgz",
       "integrity": "sha1-KjxBso3UW2K2Nnbst0ABJlrp7dg=",
       "dev": true,
       "requires": {
@@ -9981,19 +9981,19 @@
     },
     "stable": {
       "version": "0.1.8",
-      "resolved": "https://registry.npm.taobao.org/stable/download/stable-0.1.8.tgz",
+      "resolved": "https://registry.npmjs.org/stable/-/stable-0.1.8.tgz",
       "integrity": "sha1-g26zyDgv4pNv6vVEYxAXzn1Ho88=",
       "dev": true
     },
     "stackframe": {
       "version": "1.0.4",
-      "resolved": "https://registry.npm.taobao.org/stackframe/download/stackframe-1.0.4.tgz",
+      "resolved": "https://registry.npmjs.org/stackframe/-/stackframe-1.0.4.tgz",
       "integrity": "sha1-NXskqZL5Qny6a1RdlqFO0svKGHs=",
       "dev": true
     },
     "static-extend": {
       "version": "0.1.2",
-      "resolved": "https://registry.npm.taobao.org/static-extend/download/static-extend-0.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/static-extend/-/static-extend-0.1.2.tgz",
       "integrity": "sha1-YICcOcv/VTNyJv1eC1IPNB8ftcY=",
       "dev": true,
       "requires": {
@@ -10003,7 +10003,7 @@
       "dependencies": {
         "define-property": {
           "version": "0.2.5",
-          "resolved": "https://registry.npm.taobao.org/define-property/download/define-property-0.2.5.tgz",
+          "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
           "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
           "dev": true,
           "requires": {
@@ -10014,19 +10014,19 @@
     },
     "statuses": {
       "version": "1.5.0",
-      "resolved": "https://registry.npm.taobao.org/statuses/download/statuses-1.5.0.tgz",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz",
       "integrity": "sha1-Fhx9rBd2Wf2YEfQ3cfqZOBR4Yow=",
       "dev": true
     },
     "stealthy-require": {
       "version": "1.1.1",
-      "resolved": "https://registry.npm.taobao.org/stealthy-require/download/stealthy-require-1.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/stealthy-require/-/stealthy-require-1.1.1.tgz",
       "integrity": "sha1-NbCYdbT/SfJqd35QmzCQoyJr8ks=",
       "dev": true
     },
     "stream-browserify": {
       "version": "2.0.2",
-      "resolved": "https://registry.npm.taobao.org/stream-browserify/download/stream-browserify-2.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/stream-browserify/-/stream-browserify-2.0.2.tgz",
       "integrity": "sha1-h1IdOKRKp+6RzhzSpH3wy0ndZgs=",
       "dev": true,
       "requires": {
@@ -10036,7 +10036,7 @@
     },
     "stream-each": {
       "version": "1.2.3",
-      "resolved": "https://registry.npm.taobao.org/stream-each/download/stream-each-1.2.3.tgz",
+      "resolved": "https://registry.npmjs.org/stream-each/-/stream-each-1.2.3.tgz",
       "integrity": "sha1-6+J6DDibBPvMIzZClS4Qcxr6m64=",
       "dev": true,
       "requires": {
@@ -10046,7 +10046,7 @@
     },
     "stream-http": {
       "version": "2.8.3",
-      "resolved": "https://registry.npm.taobao.org/stream-http/download/stream-http-2.8.3.tgz",
+      "resolved": "https://registry.npmjs.org/stream-http/-/stream-http-2.8.3.tgz",
       "integrity": "sha1-stJCRpKIpaJ+xP6JM6z2I95lFPw=",
       "dev": true,
       "requires": {
@@ -10059,19 +10059,19 @@
     },
     "stream-shift": {
       "version": "1.0.0",
-      "resolved": "https://registry.npm.taobao.org/stream-shift/download/stream-shift-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.0.tgz",
       "integrity": "sha1-1cdSgl5TZ+eG944Y5EXqIjoVWVI=",
       "dev": true
     },
     "strict-uri-encode": {
       "version": "1.1.0",
-      "resolved": "https://registry.npm.taobao.org/strict-uri-encode/download/strict-uri-encode-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-1.1.0.tgz",
       "integrity": "sha1-J5siXfHVgrH1TmWt3UNS4Y+qBxM=",
       "dev": true
     },
     "string-width": {
       "version": "2.1.1",
-      "resolved": "https://registry.npm.taobao.org/string-width/download/string-width-2.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
       "integrity": "sha1-q5Pyeo3BPSjKyBXEYhQ6bZASrp4=",
       "dev": true,
       "requires": {
@@ -10081,13 +10081,13 @@
       "dependencies": {
         "ansi-regex": {
           "version": "3.0.0",
-          "resolved": "https://registry.npm.taobao.org/ansi-regex/download/ansi-regex-3.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
           "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
           "dev": true
         },
         "strip-ansi": {
           "version": "4.0.0",
-          "resolved": "https://registry.npm.taobao.org/strip-ansi/download/strip-ansi-4.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
           "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
           "dev": true,
           "requires": {
@@ -10098,7 +10098,7 @@
     },
     "string.prototype.padend": {
       "version": "3.0.0",
-      "resolved": "https://registry.npm.taobao.org/string.prototype.padend/download/string.prototype.padend-3.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/string.prototype.padend/-/string.prototype.padend-3.0.0.tgz",
       "integrity": "sha1-86rvfBcZ8XDF6rHDK/eA2W4h8vA=",
       "dev": true,
       "requires": {
@@ -10109,7 +10109,7 @@
     },
     "string.prototype.padstart": {
       "version": "3.0.0",
-      "resolved": "https://registry.npm.taobao.org/string.prototype.padstart/download/string.prototype.padstart-3.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/string.prototype.padstart/-/string.prototype.padstart-3.0.0.tgz",
       "integrity": "sha1-W8+tOfRkm7LQMSkuGbzwtRDUskI=",
       "dev": true,
       "requires": {
@@ -10120,7 +10120,7 @@
     },
     "string_decoder": {
       "version": "1.1.1",
-      "resolved": "https://registry.npm.taobao.org/string_decoder/download/string_decoder-1.1.1.tgz?cache=0&sync_timestamp=1565170823020&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fstring_decoder%2Fdownload%2Fstring_decoder-1.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
       "integrity": "sha1-nPFhG6YmhdcDCunkujQUnDrwP8g=",
       "dev": true,
       "requires": {
@@ -10129,7 +10129,7 @@
     },
     "strip-ansi": {
       "version": "5.2.0",
-      "resolved": "https://registry.npm.taobao.org/strip-ansi/download/strip-ansi-5.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
       "integrity": "sha1-jJpTb+tq/JYr36WxBKUJHBrZwK4=",
       "dev": true,
       "requires": {
@@ -10138,25 +10138,25 @@
     },
     "strip-eof": {
       "version": "1.0.0",
-      "resolved": "https://registry.npm.taobao.org/strip-eof/download/strip-eof-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
       "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8=",
       "dev": true
     },
     "strip-indent": {
       "version": "2.0.0",
-      "resolved": "https://registry.npm.taobao.org/strip-indent/download/strip-indent-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-2.0.0.tgz",
       "integrity": "sha1-XvjbKV0B5u1sv3qrlpmNeCJSe2g=",
       "dev": true
     },
     "strip-json-comments": {
       "version": "2.0.1",
-      "resolved": "https://registry.npm.taobao.org/strip-json-comments/download/strip-json-comments-2.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
       "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
       "dev": true
     },
     "stylehacks": {
       "version": "4.0.3",
-      "resolved": "https://registry.npm.taobao.org/stylehacks/download/stylehacks-4.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/stylehacks/-/stylehacks-4.0.3.tgz",
       "integrity": "sha1-Zxj8r00eB9ihMYaQiB6NlnJqcdU=",
       "dev": true,
       "requires": {
@@ -10167,7 +10167,7 @@
       "dependencies": {
         "postcss-selector-parser": {
           "version": "3.1.1",
-          "resolved": "https://registry.npm.taobao.org/postcss-selector-parser/download/postcss-selector-parser-3.1.1.tgz",
+          "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-3.1.1.tgz",
           "integrity": "sha1-T4dfSvsMllc9XPTXQBGu4lCn6GU=",
           "dev": true,
           "requires": {
@@ -10180,7 +10180,7 @@
     },
     "supports-color": {
       "version": "5.5.0",
-      "resolved": "https://registry.npm.taobao.org/supports-color/download/supports-color-5.5.0.tgz",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
       "integrity": "sha1-4uaaRKyHcveKHsCzW2id9lMO/I8=",
       "dev": true,
       "requires": {
@@ -10189,13 +10189,13 @@
     },
     "svg-tags": {
       "version": "1.0.0",
-      "resolved": "https://registry.npm.taobao.org/svg-tags/download/svg-tags-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/svg-tags/-/svg-tags-1.0.0.tgz",
       "integrity": "sha1-WPcc7jvVGbWdSyqEO2x95krAR2Q=",
       "dev": true
     },
     "svgo": {
       "version": "1.3.0",
-      "resolved": "https://registry.npm.taobao.org/svgo/download/svgo-1.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/svgo/-/svgo-1.3.0.tgz",
       "integrity": "sha1-uuUbqV3tmjOja3xGzpw1mukVQxM=",
       "dev": true,
       "requires": {
@@ -10216,7 +10216,7 @@
     },
     "table": {
       "version": "4.0.2",
-      "resolved": "https://registry.npm.taobao.org/table/download/table-4.0.2.tgz?cache=0&sync_timestamp=1564593837345&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Ftable%2Fdownload%2Ftable-4.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/table/-/table-4.0.2.tgz",
       "integrity": "sha1-ozRHN1OR52atNNNIbm4q7chNLjY=",
       "dev": true,
       "optional": true,
@@ -10231,7 +10231,7 @@
       "dependencies": {
         "ajv": {
           "version": "5.5.2",
-          "resolved": "https://registry.npm.taobao.org/ajv/download/ajv-5.5.2.tgz?cache=0&sync_timestamp=1563141444360&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fajv%2Fdownload%2Fajv-5.5.2.tgz",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz",
           "integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
           "dev": true,
           "optional": true,
@@ -10244,21 +10244,21 @@
         },
         "ajv-keywords": {
           "version": "2.1.1",
-          "resolved": "https://registry.npm.taobao.org/ajv-keywords/download/ajv-keywords-2.1.1.tgz",
+          "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-2.1.1.tgz",
           "integrity": "sha1-YXmX/F9gV2iUxDX5QNgZ4TW4B2I=",
           "dev": true,
           "optional": true
         },
         "fast-deep-equal": {
           "version": "1.1.0",
-          "resolved": "https://registry.npm.taobao.org/fast-deep-equal/download/fast-deep-equal-1.1.0.tgz",
+          "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.1.0.tgz",
           "integrity": "sha1-wFNHeBfIa1HaqFPIHgWbcz0CNhQ=",
           "dev": true,
           "optional": true
         },
         "json-schema-traverse": {
           "version": "0.3.1",
-          "resolved": "https://registry.npm.taobao.org/json-schema-traverse/download/json-schema-traverse-0.3.1.tgz",
+          "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.3.1.tgz",
           "integrity": "sha1-NJptRMU6Ud6JtAgFxdXlm0F9M0A=",
           "dev": true,
           "optional": true
@@ -10267,13 +10267,13 @@
     },
     "tapable": {
       "version": "1.1.3",
-      "resolved": "https://registry.npm.taobao.org/tapable/download/tapable-1.1.3.tgz",
+      "resolved": "https://registry.npmjs.org/tapable/-/tapable-1.1.3.tgz",
       "integrity": "sha1-ofzMBrWNth/XpF2i2kT186Pme6I=",
       "dev": true
     },
     "terser": {
       "version": "4.1.4",
-      "resolved": "https://registry.npm.taobao.org/terser/download/terser-4.1.4.tgz?cache=0&sync_timestamp=1565466195242&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fterser%2Fdownload%2Fterser-4.1.4.tgz",
+      "resolved": "https://registry.npmjs.org/terser/-/terser-4.1.4.tgz",
       "integrity": "sha1-RHi2oIuwlqYeeT/qGkQ0QIurk2w=",
       "dev": true,
       "requires": {
@@ -10284,7 +10284,7 @@
       "dependencies": {
         "source-map": {
           "version": "0.6.1",
-          "resolved": "https://registry.npm.taobao.org/source-map/download/source-map-0.6.1.tgz",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
           "integrity": "sha1-dHIq8y6WFOnCh6jQu95IteLxomM=",
           "dev": true
         }
@@ -10292,7 +10292,7 @@
     },
     "terser-webpack-plugin": {
       "version": "1.4.1",
-      "resolved": "https://registry.npm.taobao.org/terser-webpack-plugin/download/terser-webpack-plugin-1.4.1.tgz?cache=0&sync_timestamp=1564575178544&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fterser-webpack-plugin%2Fdownload%2Fterser-webpack-plugin-1.4.1.tgz",
+      "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-1.4.1.tgz",
       "integrity": "sha1-YbGOQOruW+l+dxzbsQ7RKAiIwrQ=",
       "dev": true,
       "requires": {
@@ -10309,7 +10309,7 @@
       "dependencies": {
         "schema-utils": {
           "version": "1.0.0",
-          "resolved": "https://registry.npm.taobao.org/schema-utils/download/schema-utils-1.0.0.tgz?cache=0&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fschema-utils%2Fdownload%2Fschema-utils-1.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-1.0.0.tgz",
           "integrity": "sha1-C3mpMgTXtgDUsoUNH2bCo0lRx3A=",
           "dev": true,
           "requires": {
@@ -10320,7 +10320,7 @@
         },
         "source-map": {
           "version": "0.6.1",
-          "resolved": "https://registry.npm.taobao.org/source-map/download/source-map-0.6.1.tgz",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
           "integrity": "sha1-dHIq8y6WFOnCh6jQu95IteLxomM=",
           "dev": true
         }
@@ -10328,13 +10328,13 @@
     },
     "text-table": {
       "version": "0.2.0",
-      "resolved": "https://registry.npm.taobao.org/text-table/download/text-table-0.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
       "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
       "dev": true
     },
     "thenify": {
       "version": "3.3.0",
-      "resolved": "https://registry.npm.taobao.org/thenify/download/thenify-3.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/thenify/-/thenify-3.3.0.tgz",
       "integrity": "sha1-5p44obq+lpsBCCB5eLn2K4hgSDk=",
       "dev": true,
       "requires": {
@@ -10343,7 +10343,7 @@
     },
     "thenify-all": {
       "version": "1.6.0",
-      "resolved": "https://registry.npm.taobao.org/thenify-all/download/thenify-all-1.6.0.tgz",
+      "resolved": "https://registry.npmjs.org/thenify-all/-/thenify-all-1.6.0.tgz",
       "integrity": "sha1-GhkY1ALY/D+Y+/I02wvMjMEOlyY=",
       "dev": true,
       "requires": {
@@ -10352,7 +10352,7 @@
     },
     "thread-loader": {
       "version": "2.1.3",
-      "resolved": "https://registry.npm.taobao.org/thread-loader/download/thread-loader-2.1.3.tgz",
+      "resolved": "https://registry.npmjs.org/thread-loader/-/thread-loader-2.1.3.tgz",
       "integrity": "sha1-y9LBOfwrLebp0o9iKGq3cMGsvdo=",
       "dev": true,
       "requires": {
@@ -10363,13 +10363,13 @@
     },
     "through": {
       "version": "2.3.8",
-      "resolved": "https://registry.npm.taobao.org/through/download/through-2.3.8.tgz",
+      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
       "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
       "dev": true
     },
     "through2": {
       "version": "2.0.5",
-      "resolved": "https://registry.npm.taobao.org/through2/download/through2-2.0.5.tgz",
+      "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.5.tgz",
       "integrity": "sha1-AcHjnrMdB8t9A6lqcIIyYLIxMs0=",
       "dev": true,
       "requires": {
@@ -10379,13 +10379,13 @@
     },
     "thunky": {
       "version": "1.0.3",
-      "resolved": "https://registry.npm.taobao.org/thunky/download/thunky-1.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/thunky/-/thunky-1.0.3.tgz",
       "integrity": "sha1-9d9zJFNAewkZHa5z4qjMc/OBqCY=",
       "dev": true
     },
     "timers-browserify": {
       "version": "2.0.11",
-      "resolved": "https://registry.npm.taobao.org/timers-browserify/download/timers-browserify-2.0.11.tgz",
+      "resolved": "https://registry.npmjs.org/timers-browserify/-/timers-browserify-2.0.11.tgz",
       "integrity": "sha1-gAsfPu4nLlvFPuRloE0OgEwxIR8=",
       "dev": true,
       "requires": {
@@ -10394,13 +10394,13 @@
     },
     "timsort": {
       "version": "0.3.0",
-      "resolved": "https://registry.npm.taobao.org/timsort/download/timsort-0.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/timsort/-/timsort-0.3.0.tgz",
       "integrity": "sha1-QFQRqOfmM5/mTbmiNN4R3DHgK9Q=",
       "dev": true
     },
     "tmp": {
       "version": "0.0.33",
-      "resolved": "https://registry.npm.taobao.org/tmp/download/tmp-0.0.33.tgz",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
       "integrity": "sha1-bTQzWIl2jSGyvNoKonfO07G/rfk=",
       "dev": true,
       "requires": {
@@ -10409,19 +10409,19 @@
     },
     "to-arraybuffer": {
       "version": "1.0.1",
-      "resolved": "https://registry.npm.taobao.org/to-arraybuffer/download/to-arraybuffer-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/to-arraybuffer/-/to-arraybuffer-1.0.1.tgz",
       "integrity": "sha1-fSKbH8xjfkZsoIEYCDanqr/4P0M=",
       "dev": true
     },
     "to-fast-properties": {
       "version": "2.0.0",
-      "resolved": "https://registry.npm.taobao.org/to-fast-properties/download/to-fast-properties-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
       "integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=",
       "dev": true
     },
     "to-object-path": {
       "version": "0.3.0",
-      "resolved": "https://registry.npm.taobao.org/to-object-path/download/to-object-path-0.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/to-object-path/-/to-object-path-0.3.0.tgz",
       "integrity": "sha1-KXWIt7Dn4KwI4E5nL4XB9JmeF68=",
       "dev": true,
       "requires": {
@@ -10430,7 +10430,7 @@
       "dependencies": {
         "kind-of": {
           "version": "3.2.2",
-          "resolved": "https://registry.npm.taobao.org/kind-of/download/kind-of-3.2.2.tgz",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
           "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
           "dev": true,
           "requires": {
@@ -10441,7 +10441,7 @@
     },
     "to-regex": {
       "version": "3.0.2",
-      "resolved": "https://registry.npm.taobao.org/to-regex/download/to-regex-3.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/to-regex/-/to-regex-3.0.2.tgz",
       "integrity": "sha1-E8/dmzNlUvMLUfM6iuG0Knp1mc4=",
       "dev": true,
       "requires": {
@@ -10453,7 +10453,7 @@
     },
     "to-regex-range": {
       "version": "2.1.1",
-      "resolved": "https://registry.npm.taobao.org/to-regex-range/download/to-regex-range-2.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-2.1.1.tgz",
       "integrity": "sha1-fIDBe53+vlmeJzZ+DU3VWQFB2zg=",
       "dev": true,
       "requires": {
@@ -10463,19 +10463,19 @@
     },
     "toidentifier": {
       "version": "1.0.0",
-      "resolved": "https://registry.npm.taobao.org/toidentifier/download/toidentifier-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.0.tgz",
       "integrity": "sha1-fhvjRw8ed5SLxD2Uo8j013UrpVM=",
       "dev": true
     },
     "toposort": {
       "version": "1.0.7",
-      "resolved": "https://registry.npm.taobao.org/toposort/download/toposort-1.0.7.tgz",
+      "resolved": "https://registry.npmjs.org/toposort/-/toposort-1.0.7.tgz",
       "integrity": "sha1-LmhELZ9k7HILjMieZEOsbKqVACk=",
       "dev": true
     },
     "tough-cookie": {
       "version": "2.4.3",
-      "resolved": "https://registry.npm.taobao.org/tough-cookie/download/tough-cookie-2.4.3.tgz",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.4.3.tgz",
       "integrity": "sha1-U/Nto/R3g7CSWvoG/587FlKA94E=",
       "dev": true,
       "requires": {
@@ -10485,7 +10485,7 @@
       "dependencies": {
         "punycode": {
           "version": "1.4.1",
-          "resolved": "https://registry.npm.taobao.org/punycode/download/punycode-1.4.1.tgz",
+          "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
           "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4=",
           "dev": true
         }
@@ -10493,31 +10493,31 @@
     },
     "trim-right": {
       "version": "1.0.1",
-      "resolved": "https://registry.npm.taobao.org/trim-right/download/trim-right-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/trim-right/-/trim-right-1.0.1.tgz",
       "integrity": "sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM=",
       "dev": true
     },
     "tryer": {
       "version": "1.0.1",
-      "resolved": "https://registry.npm.taobao.org/tryer/download/tryer-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/tryer/-/tryer-1.0.1.tgz",
       "integrity": "sha1-8shUBoALmw90yfdGW4HqrSQSUvg=",
       "dev": true
     },
     "tslib": {
       "version": "1.10.0",
-      "resolved": "https://registry.npm.taobao.org/tslib/download/tslib-1.10.0.tgz",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.10.0.tgz",
       "integrity": "sha1-w8GflZc/sKYpc/sJ2Q2WHuQ+XIo=",
       "dev": true
     },
     "tty-browserify": {
       "version": "0.0.0",
-      "resolved": "https://registry.npm.taobao.org/tty-browserify/download/tty-browserify-0.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/tty-browserify/-/tty-browserify-0.0.0.tgz",
       "integrity": "sha1-oVe6QC2iTpv5V/mqadUk7tQpAaY=",
       "dev": true
     },
     "tunnel-agent": {
       "version": "0.6.0",
-      "resolved": "https://registry.npm.taobao.org/tunnel-agent/download/tunnel-agent-0.6.0.tgz",
+      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
       "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
       "dev": true,
       "requires": {
@@ -10526,13 +10526,13 @@
     },
     "tweetnacl": {
       "version": "0.14.5",
-      "resolved": "https://registry.npm.taobao.org/tweetnacl/download/tweetnacl-0.14.5.tgz",
+      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
       "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
       "dev": true
     },
     "type-check": {
       "version": "0.3.2",
-      "resolved": "https://registry.npm.taobao.org/type-check/download/type-check-0.3.2.tgz",
+      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
       "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
       "dev": true,
       "requires": {
@@ -10541,13 +10541,13 @@
     },
     "type-fest": {
       "version": "0.6.0",
-      "resolved": "https://registry.npm.taobao.org/type-fest/download/type-fest-0.6.0.tgz",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.6.0.tgz",
       "integrity": "sha1-jSojcNPfiG61yQraHFv2GIrPg4s=",
       "dev": true
     },
     "type-is": {
       "version": "1.6.18",
-      "resolved": "https://registry.npm.taobao.org/type-is/download/type-is-1.6.18.tgz",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.18.tgz",
       "integrity": "sha1-TlUs0F3wlGfcvE73Od6J8s83wTE=",
       "dev": true,
       "requires": {
@@ -10557,13 +10557,13 @@
     },
     "typedarray": {
       "version": "0.0.6",
-      "resolved": "https://registry.npm.taobao.org/typedarray/download/typedarray-0.0.6.tgz",
+      "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
       "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
       "dev": true
     },
     "uglify-js": {
       "version": "3.4.10",
-      "resolved": "https://registry.npm.taobao.org/uglify-js/download/uglify-js-3.4.10.tgz",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.4.10.tgz",
       "integrity": "sha1-mtlWPY6zrN+404WX0q8dgV9qdV8=",
       "dev": true,
       "requires": {
@@ -10573,13 +10573,13 @@
       "dependencies": {
         "commander": {
           "version": "2.19.0",
-          "resolved": "https://registry.npm.taobao.org/commander/download/commander-2.19.0.tgz?cache=0&sync_timestamp=1565398176321&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fcommander%2Fdownload%2Fcommander-2.19.0.tgz",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.19.0.tgz",
           "integrity": "sha1-9hmKqE5bg8RgVLlN3tv+1e6f8So=",
           "dev": true
         },
         "source-map": {
           "version": "0.6.1",
-          "resolved": "https://registry.npm.taobao.org/source-map/download/source-map-0.6.1.tgz",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
           "integrity": "sha1-dHIq8y6WFOnCh6jQu95IteLxomM=",
           "dev": true
         }
@@ -10587,13 +10587,13 @@
     },
     "unicode-canonical-property-names-ecmascript": {
       "version": "1.0.4",
-      "resolved": "https://registry.npm.taobao.org/unicode-canonical-property-names-ecmascript/download/unicode-canonical-property-names-ecmascript-1.0.4.tgz",
+      "resolved": "https://registry.npmjs.org/unicode-canonical-property-names-ecmascript/-/unicode-canonical-property-names-ecmascript-1.0.4.tgz",
       "integrity": "sha1-JhmADEyCWADv3YNDr33Zkzy+KBg=",
       "dev": true
     },
     "unicode-match-property-ecmascript": {
       "version": "1.0.4",
-      "resolved": "https://registry.npm.taobao.org/unicode-match-property-ecmascript/download/unicode-match-property-ecmascript-1.0.4.tgz",
+      "resolved": "https://registry.npmjs.org/unicode-match-property-ecmascript/-/unicode-match-property-ecmascript-1.0.4.tgz",
       "integrity": "sha1-jtKjJWmWG86SJ9Cc0/+7j+1fAgw=",
       "dev": true,
       "requires": {
@@ -10603,19 +10603,19 @@
     },
     "unicode-match-property-value-ecmascript": {
       "version": "1.1.0",
-      "resolved": "https://registry.npm.taobao.org/unicode-match-property-value-ecmascript/download/unicode-match-property-value-ecmascript-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/unicode-match-property-value-ecmascript/-/unicode-match-property-value-ecmascript-1.1.0.tgz",
       "integrity": "sha1-W0tCbgjROoA2Xg1lesemwexGonc=",
       "dev": true
     },
     "unicode-property-aliases-ecmascript": {
       "version": "1.0.5",
-      "resolved": "https://registry.npm.taobao.org/unicode-property-aliases-ecmascript/download/unicode-property-aliases-ecmascript-1.0.5.tgz",
+      "resolved": "https://registry.npmjs.org/unicode-property-aliases-ecmascript/-/unicode-property-aliases-ecmascript-1.0.5.tgz",
       "integrity": "sha1-qcxsx85joKMCP8meNBuUQx1AWlc=",
       "dev": true
     },
     "union-value": {
       "version": "1.0.1",
-      "resolved": "https://registry.npm.taobao.org/union-value/download/union-value-1.0.1.tgz?cache=0&sync_timestamp=1561410740419&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Funion-value%2Fdownload%2Funion-value-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/union-value/-/union-value-1.0.1.tgz",
       "integrity": "sha1-C2/nuDWuzaYcbqTU8CwUIh4QmEc=",
       "dev": true,
       "requires": {
@@ -10627,19 +10627,19 @@
     },
     "uniq": {
       "version": "1.0.1",
-      "resolved": "https://registry.npm.taobao.org/uniq/download/uniq-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/uniq/-/uniq-1.0.1.tgz",
       "integrity": "sha1-sxxa6CVIRKOoKBVBzisEuGWnNP8=",
       "dev": true
     },
     "uniqs": {
       "version": "2.0.0",
-      "resolved": "https://registry.npm.taobao.org/uniqs/download/uniqs-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/uniqs/-/uniqs-2.0.0.tgz",
       "integrity": "sha1-/+3ks2slKQaW5uFl1KWe25mOawI=",
       "dev": true
     },
     "unique-filename": {
       "version": "1.1.1",
-      "resolved": "https://registry.npm.taobao.org/unique-filename/download/unique-filename-1.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/unique-filename/-/unique-filename-1.1.1.tgz",
       "integrity": "sha1-HWl2k2mtoFgxA6HmrodoG1ZXMjA=",
       "dev": true,
       "requires": {
@@ -10648,7 +10648,7 @@
     },
     "unique-slug": {
       "version": "2.0.2",
-      "resolved": "https://registry.npm.taobao.org/unique-slug/download/unique-slug-2.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/unique-slug/-/unique-slug-2.0.2.tgz",
       "integrity": "sha1-uqvOkQg/xk6UWw861hPiZPfNTmw=",
       "dev": true,
       "requires": {
@@ -10657,25 +10657,25 @@
     },
     "universalify": {
       "version": "0.1.2",
-      "resolved": "https://registry.npm.taobao.org/universalify/download/universalify-0.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
       "integrity": "sha1-tkb2m+OULavOzJ1mOcgNwQXvqmY=",
       "dev": true
     },
     "unpipe": {
       "version": "1.0.0",
-      "resolved": "https://registry.npm.taobao.org/unpipe/download/unpipe-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
       "integrity": "sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw=",
       "dev": true
     },
     "unquote": {
       "version": "1.1.1",
-      "resolved": "https://registry.npm.taobao.org/unquote/download/unquote-1.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/unquote/-/unquote-1.1.1.tgz",
       "integrity": "sha1-j97XMk7G6IoP+LkF58CYzcCG1UQ=",
       "dev": true
     },
     "unset-value": {
       "version": "1.0.0",
-      "resolved": "https://registry.npm.taobao.org/unset-value/download/unset-value-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/unset-value/-/unset-value-1.0.0.tgz",
       "integrity": "sha1-g3aHP30jNRef+x5vw6jtDfyKtVk=",
       "dev": true,
       "requires": {
@@ -10685,7 +10685,7 @@
       "dependencies": {
         "has-value": {
           "version": "0.3.1",
-          "resolved": "https://registry.npm.taobao.org/has-value/download/has-value-0.3.1.tgz",
+          "resolved": "https://registry.npmjs.org/has-value/-/has-value-0.3.1.tgz",
           "integrity": "sha1-ex9YutpiyoJ+wKIHgCVlSEWZXh8=",
           "dev": true,
           "requires": {
@@ -10696,7 +10696,7 @@
           "dependencies": {
             "isobject": {
               "version": "2.1.0",
-              "resolved": "https://registry.npm.taobao.org/isobject/download/isobject-2.1.0.tgz",
+              "resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
               "integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
               "dev": true,
               "requires": {
@@ -10707,7 +10707,7 @@
         },
         "has-values": {
           "version": "0.1.4",
-          "resolved": "https://registry.npm.taobao.org/has-values/download/has-values-0.1.4.tgz",
+          "resolved": "https://registry.npmjs.org/has-values/-/has-values-0.1.4.tgz",
           "integrity": "sha1-bWHeldkd/Km5oCCJrThL/49it3E=",
           "dev": true
         }
@@ -10715,19 +10715,19 @@
     },
     "upath": {
       "version": "1.1.2",
-      "resolved": "https://registry.npm.taobao.org/upath/download/upath-1.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/upath/-/upath-1.1.2.tgz",
       "integrity": "sha1-PbZYYA7a7sy+bbXmhNZ+6MKs0Gg=",
       "dev": true
     },
     "upper-case": {
       "version": "1.1.3",
-      "resolved": "https://registry.npm.taobao.org/upper-case/download/upper-case-1.1.3.tgz",
+      "resolved": "https://registry.npmjs.org/upper-case/-/upper-case-1.1.3.tgz",
       "integrity": "sha1-9rRQHC7EzdJrp4vnIilh3ndiFZg=",
       "dev": true
     },
     "uri-js": {
       "version": "4.2.2",
-      "resolved": "https://registry.npm.taobao.org/uri-js/download/uri-js-4.2.2.tgz",
+      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.2.2.tgz",
       "integrity": "sha1-lMVA4f93KVbiKZUHwBCupsiDjrA=",
       "dev": true,
       "requires": {
@@ -10736,13 +10736,13 @@
     },
     "urix": {
       "version": "0.1.0",
-      "resolved": "https://registry.npm.taobao.org/urix/download/urix-0.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/urix/-/urix-0.1.0.tgz",
       "integrity": "sha1-2pN/emLiH+wf0Y1Js1wpNQZ6bHI=",
       "dev": true
     },
     "url": {
       "version": "0.11.0",
-      "resolved": "https://registry.npm.taobao.org/url/download/url-0.11.0.tgz",
+      "resolved": "https://registry.npmjs.org/url/-/url-0.11.0.tgz",
       "integrity": "sha1-ODjpfPxgUh63PFJajlW/3Z4uKPE=",
       "dev": true,
       "requires": {
@@ -10752,7 +10752,7 @@
       "dependencies": {
         "punycode": {
           "version": "1.3.2",
-          "resolved": "https://registry.npm.taobao.org/punycode/download/punycode-1.3.2.tgz",
+          "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz",
           "integrity": "sha1-llOgNvt8HuQjQvIyXM7v6jkmxI0=",
           "dev": true
         }
@@ -10760,7 +10760,7 @@
     },
     "url-loader": {
       "version": "1.1.2",
-      "resolved": "https://registry.npm.taobao.org/url-loader/download/url-loader-1.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/url-loader/-/url-loader-1.1.2.tgz",
       "integrity": "sha1-uXHRkbg69pPF4/6kBkvp4fLX+Ng=",
       "dev": true,
       "requires": {
@@ -10771,7 +10771,7 @@
       "dependencies": {
         "schema-utils": {
           "version": "1.0.0",
-          "resolved": "https://registry.npm.taobao.org/schema-utils/download/schema-utils-1.0.0.tgz?cache=0&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fschema-utils%2Fdownload%2Fschema-utils-1.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-1.0.0.tgz",
           "integrity": "sha1-C3mpMgTXtgDUsoUNH2bCo0lRx3A=",
           "dev": true,
           "requires": {
@@ -10784,7 +10784,7 @@
     },
     "url-parse": {
       "version": "1.4.7",
-      "resolved": "https://registry.npm.taobao.org/url-parse/download/url-parse-1.4.7.tgz",
+      "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.4.7.tgz",
       "integrity": "sha1-qKg1NejACjFuQDpdtKwbm4U64ng=",
       "dev": true,
       "requires": {
@@ -10794,13 +10794,13 @@
     },
     "use": {
       "version": "3.1.1",
-      "resolved": "https://registry.npm.taobao.org/use/download/use-3.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/use/-/use-3.1.1.tgz",
       "integrity": "sha1-1QyMrHmhn7wg8pEfVuuXP04QBw8=",
       "dev": true
     },
     "util": {
       "version": "0.11.1",
-      "resolved": "https://registry.npm.taobao.org/util/download/util-0.11.1.tgz",
+      "resolved": "https://registry.npmjs.org/util/-/util-0.11.1.tgz",
       "integrity": "sha1-MjZzNyDsZLsn9uJvQhqqLhtYjWE=",
       "dev": true,
       "requires": {
@@ -10809,7 +10809,7 @@
       "dependencies": {
         "inherits": {
           "version": "2.0.3",
-          "resolved": "https://registry.npm.taobao.org/inherits/download/inherits-2.0.3.tgz?cache=0&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Finherits%2Fdownload%2Finherits-2.0.3.tgz",
+          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
           "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
           "dev": true
         }
@@ -10817,13 +10817,13 @@
     },
     "util-deprecate": {
       "version": "1.0.2",
-      "resolved": "https://registry.npm.taobao.org/util-deprecate/download/util-deprecate-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
       "dev": true
     },
     "util.promisify": {
       "version": "1.0.0",
-      "resolved": "https://registry.npm.taobao.org/util.promisify/download/util.promisify-1.0.0.tgz?cache=0&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Futil.promisify%2Fdownload%2Futil.promisify-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/util.promisify/-/util.promisify-1.0.0.tgz",
       "integrity": "sha1-RA9xZaRZyaFtwUXrjnLzVocJcDA=",
       "dev": true,
       "requires": {
@@ -10833,25 +10833,25 @@
     },
     "utila": {
       "version": "0.4.0",
-      "resolved": "https://registry.npm.taobao.org/utila/download/utila-0.4.0.tgz",
+      "resolved": "https://registry.npmjs.org/utila/-/utila-0.4.0.tgz",
       "integrity": "sha1-ihagXURWV6Oupe7MWxKk+lN5dyw=",
       "dev": true
     },
     "utils-merge": {
       "version": "1.0.1",
-      "resolved": "https://registry.npm.taobao.org/utils-merge/download/utils-merge-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
       "integrity": "sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM=",
       "dev": true
     },
     "uuid": {
       "version": "3.3.2",
-      "resolved": "https://registry.npm.taobao.org/uuid/download/uuid-3.3.2.tgz",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
       "integrity": "sha1-G0r0lV6zB3xQHCOHL8ZROBFYcTE=",
       "dev": true
     },
     "validate-npm-package-license": {
       "version": "3.0.4",
-      "resolved": "https://registry.npm.taobao.org/validate-npm-package-license/download/validate-npm-package-license-3.0.4.tgz",
+      "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz",
       "integrity": "sha1-/JH2uce6FchX9MssXe/uw51PQQo=",
       "dev": true,
       "requires": {
@@ -10861,19 +10861,19 @@
     },
     "vary": {
       "version": "1.1.2",
-      "resolved": "https://registry.npm.taobao.org/vary/download/vary-1.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
       "integrity": "sha1-IpnwLG3tMNSllhsLn3RSShj2NPw=",
       "dev": true
     },
     "vendors": {
       "version": "1.0.3",
-      "resolved": "https://registry.npm.taobao.org/vendors/download/vendors-1.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/vendors/-/vendors-1.0.3.tgz",
       "integrity": "sha1-pkZ3gavTZiF8BQ+CAuflDMnu+MA=",
       "dev": true
     },
     "verror": {
       "version": "1.10.0",
-      "resolved": "https://registry.npm.taobao.org/verror/download/verror-1.10.0.tgz",
+      "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
       "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
       "dev": true,
       "requires": {
@@ -10884,24 +10884,24 @@
     },
     "vm-browserify": {
       "version": "1.1.0",
-      "resolved": "https://registry.npm.taobao.org/vm-browserify/download/vm-browserify-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/vm-browserify/-/vm-browserify-1.1.0.tgz",
       "integrity": "sha1-vXbWojMj4sqP+hICjcBFWcdfkBk=",
       "dev": true
     },
     "vue": {
       "version": "2.6.10",
-      "resolved": "https://registry.npm.taobao.org/vue/download/vue-2.6.10.tgz",
+      "resolved": "https://registry.npmjs.org/vue/-/vue-2.6.10.tgz",
       "integrity": "sha1-pysaQqTYKnIepDjRtr9V5mGVxjc="
     },
     "vue-cli-plugin-vuetify": {
       "version": "0.6.3",
-      "resolved": "https://registry.npm.taobao.org/vue-cli-plugin-vuetify/download/vue-cli-plugin-vuetify-0.6.3.tgz",
+      "resolved": "https://registry.npmjs.org/vue-cli-plugin-vuetify/-/vue-cli-plugin-vuetify-0.6.3.tgz",
       "integrity": "sha1-cdlWzexBn1Yo0rRMQ73B5uwzVr8=",
       "dev": true
     },
     "vue-eslint-parser": {
       "version": "2.0.3",
-      "resolved": "https://registry.npm.taobao.org/vue-eslint-parser/download/vue-eslint-parser-2.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/vue-eslint-parser/-/vue-eslint-parser-2.0.3.tgz",
       "integrity": "sha1-wmjJbG2Uz+PZOKX3WTlZsMozYNE=",
       "dev": true,
       "optional": true,
@@ -10916,7 +10916,7 @@
       "dependencies": {
         "debug": {
           "version": "3.2.6",
-          "resolved": "https://registry.npm.taobao.org/debug/download/debug-3.2.6.tgz",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
           "integrity": "sha1-6D0X3hbYp++3cX7b5fsQE17uYps=",
           "dev": true,
           "optional": true,
@@ -10926,7 +10926,7 @@
         },
         "eslint-scope": {
           "version": "3.7.3",
-          "resolved": "https://registry.npm.taobao.org/eslint-scope/download/eslint-scope-3.7.3.tgz?cache=0&sync_timestamp=1563679289211&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Feslint-scope%2Fdownload%2Feslint-scope-3.7.3.tgz",
+          "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-3.7.3.tgz",
           "integrity": "sha1-u1ByANPRf2AkdjYWC0gmKEsQhTU=",
           "dev": true,
           "optional": true,
@@ -10939,13 +10939,13 @@
     },
     "vue-hot-reload-api": {
       "version": "2.3.3",
-      "resolved": "https://registry.npm.taobao.org/vue-hot-reload-api/download/vue-hot-reload-api-2.3.3.tgz",
+      "resolved": "https://registry.npmjs.org/vue-hot-reload-api/-/vue-hot-reload-api-2.3.3.tgz",
       "integrity": "sha1-J1b0bLMlgFTF9HI96K5+hzAqHM8=",
       "dev": true
     },
     "vue-loader": {
       "version": "15.7.1",
-      "resolved": "https://registry.npm.taobao.org/vue-loader/download/vue-loader-15.7.1.tgz?cache=0&sync_timestamp=1563435501637&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fvue-loader%2Fdownload%2Fvue-loader-15.7.1.tgz",
+      "resolved": "https://registry.npmjs.org/vue-loader/-/vue-loader-15.7.1.tgz",
       "integrity": "sha1-bMrNQSKqgPabqqwI/ylaYuOu/P0=",
       "dev": true,
       "requires": {
@@ -10958,7 +10958,7 @@
       "dependencies": {
         "@vue/component-compiler-utils": {
           "version": "3.0.0",
-          "resolved": "https://registry.npm.taobao.org/@vue/component-compiler-utils/download/@vue/component-compiler-utils-3.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/@vue/component-compiler-utils/-/component-compiler-utils-3.0.0.tgz",
           "integrity": "sha1-0W+ia4NsBt9bqutF89gK/EfjVjQ=",
           "dev": true,
           "requires": {
@@ -10975,7 +10975,7 @@
         },
         "lru-cache": {
           "version": "4.1.5",
-          "resolved": "https://registry.npm.taobao.org/lru-cache/download/lru-cache-4.1.5.tgz",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.5.tgz",
           "integrity": "sha1-i75Q6oW+1ZvJ4z3KuCNe6bz0Q80=",
           "dev": true,
           "requires": {
@@ -10985,13 +10985,13 @@
         },
         "source-map": {
           "version": "0.6.1",
-          "resolved": "https://registry.npm.taobao.org/source-map/download/source-map-0.6.1.tgz",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
           "integrity": "sha1-dHIq8y6WFOnCh6jQu95IteLxomM=",
           "dev": true
         },
         "yallist": {
           "version": "2.1.2",
-          "resolved": "https://registry.npm.taobao.org/yallist/download/yallist-2.1.2.tgz",
+          "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
           "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=",
           "dev": true
         }
@@ -11004,7 +11004,7 @@
     },
     "vue-style-loader": {
       "version": "4.1.2",
-      "resolved": "https://registry.npm.taobao.org/vue-style-loader/download/vue-style-loader-4.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/vue-style-loader/-/vue-style-loader-4.1.2.tgz",
       "integrity": "sha1-3t80mAbyXOtOZPOtfApE+6c1/Pg=",
       "dev": true,
       "requires": {
@@ -11014,7 +11014,7 @@
     },
     "vue-template-compiler": {
       "version": "2.6.10",
-      "resolved": "https://registry.npm.taobao.org/vue-template-compiler/download/vue-template-compiler-2.6.10.tgz",
+      "resolved": "https://registry.npmjs.org/vue-template-compiler/-/vue-template-compiler-2.6.10.tgz",
       "integrity": "sha1-MjtPNJXwT6o1AzN6gvXWUHeZycw=",
       "dev": true,
       "requires": {
@@ -11024,18 +11024,18 @@
     },
     "vue-template-es2015-compiler": {
       "version": "1.9.1",
-      "resolved": "https://registry.npm.taobao.org/vue-template-es2015-compiler/download/vue-template-es2015-compiler-1.9.1.tgz",
+      "resolved": "https://registry.npmjs.org/vue-template-es2015-compiler/-/vue-template-es2015-compiler-1.9.1.tgz",
       "integrity": "sha1-HuO8mhbsv1EYvjNLsV+cRvgvWCU=",
       "dev": true
     },
     "vuetify": {
       "version": "2.0.5",
-      "resolved": "https://registry.npm.taobao.org/vuetify/download/vuetify-2.0.5.tgz",
+      "resolved": "https://registry.npmjs.org/vuetify/-/vuetify-2.0.5.tgz",
       "integrity": "sha1-PpzZkr7S9AE7/PwEX/LjAd6zJy0="
     },
     "vuetify-loader": {
       "version": "1.3.0",
-      "resolved": "https://registry.npm.taobao.org/vuetify-loader/download/vuetify-loader-1.3.0.tgz?cache=0&sync_timestamp=1564063141569&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fvuetify-loader%2Fdownload%2Fvuetify-loader-1.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/vuetify-loader/-/vuetify-loader-1.3.0.tgz",
       "integrity": "sha1-dZ8dFvPyEe3b7v/FwLJBBfJYKwc=",
       "dev": true,
       "requires": {
@@ -11044,7 +11044,7 @@
     },
     "watchpack": {
       "version": "1.6.0",
-      "resolved": "https://registry.npm.taobao.org/watchpack/download/watchpack-1.6.0.tgz",
+      "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-1.6.0.tgz",
       "integrity": "sha1-S8EsLr6KonenHx0/FNaFx7RGzQA=",
       "dev": true,
       "requires": {
@@ -11055,7 +11055,7 @@
     },
     "wbuf": {
       "version": "1.7.3",
-      "resolved": "https://registry.npm.taobao.org/wbuf/download/wbuf-1.7.3.tgz",
+      "resolved": "https://registry.npmjs.org/wbuf/-/wbuf-1.7.3.tgz",
       "integrity": "sha1-wdjRSTFtPqhShIiVy2oL/oh7h98=",
       "dev": true,
       "requires": {
@@ -11064,7 +11064,7 @@
     },
     "wcwidth": {
       "version": "1.0.1",
-      "resolved": "https://registry.npm.taobao.org/wcwidth/download/wcwidth-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/wcwidth/-/wcwidth-1.0.1.tgz",
       "integrity": "sha1-8LDc+RW8X/FSivrbLA4XtTLaL+g=",
       "dev": true,
       "requires": {
@@ -11073,7 +11073,7 @@
     },
     "webpack": {
       "version": "4.28.4",
-      "resolved": "https://registry.npm.taobao.org/webpack/download/webpack-4.28.4.tgz?cache=0&sync_timestamp=1565103802620&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fwebpack%2Fdownload%2Fwebpack-4.28.4.tgz",
+      "resolved": "https://registry.npmjs.org/webpack/-/webpack-4.28.4.tgz",
       "integrity": "sha1-HdrmyJiH1++3Uq3ww80yubB+rNA=",
       "dev": true,
       "requires": {
@@ -11105,7 +11105,7 @@
     },
     "webpack-bundle-analyzer": {
       "version": "3.4.1",
-      "resolved": "https://registry.npm.taobao.org/webpack-bundle-analyzer/download/webpack-bundle-analyzer-3.4.1.tgz",
+      "resolved": "https://registry.npmjs.org/webpack-bundle-analyzer/-/webpack-bundle-analyzer-3.4.1.tgz",
       "integrity": "sha1-QwVEx7oWMbrM9nNHXKgwDLdKPEc=",
       "dev": true,
       "requires": {
@@ -11126,7 +11126,7 @@
       "dependencies": {
         "acorn": {
           "version": "6.2.1",
-          "resolved": "https://registry.npm.taobao.org/acorn/download/acorn-6.2.1.tgz",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.2.1.tgz",
           "integrity": "sha1-PthCLW3sCeYSHMeoQ8qGozCoa1E=",
           "dev": true
         }
@@ -11134,7 +11134,7 @@
     },
     "webpack-chain": {
       "version": "4.12.1",
-      "resolved": "https://registry.npm.taobao.org/webpack-chain/download/webpack-chain-4.12.1.tgz",
+      "resolved": "https://registry.npmjs.org/webpack-chain/-/webpack-chain-4.12.1.tgz",
       "integrity": "sha1-bIQ5u7KrVQlS1g4eqTGRQZBsAqY=",
       "dev": true,
       "requires": {
@@ -11152,7 +11152,7 @@
     },
     "webpack-dev-middleware": {
       "version": "3.7.0",
-      "resolved": "https://registry.npm.taobao.org/webpack-dev-middleware/download/webpack-dev-middleware-3.7.0.tgz",
+      "resolved": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-3.7.0.tgz",
       "integrity": "sha1-73UdJfTppcijXaYAxf2jWCtcbP8=",
       "dev": true,
       "requires": {
@@ -11164,7 +11164,7 @@
     },
     "webpack-dev-server": {
       "version": "3.8.0",
-      "resolved": "https://registry.npm.taobao.org/webpack-dev-server/download/webpack-dev-server-3.8.0.tgz?cache=0&sync_timestamp=1565370754455&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fwebpack-dev-server%2Fdownload%2Fwebpack-dev-server-3.8.0.tgz",
+      "resolved": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-3.8.0.tgz",
       "integrity": "sha1-BsxPwvRAQoUI0Ol3DaH+8Q5e8o0=",
       "dev": true,
       "requires": {
@@ -11205,13 +11205,13 @@
       "dependencies": {
         "ansi-regex": {
           "version": "2.1.1",
-          "resolved": "https://registry.npm.taobao.org/ansi-regex/download/ansi-regex-2.1.1.tgz",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
           "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
           "dev": true
         },
         "cliui": {
           "version": "4.1.0",
-          "resolved": "https://registry.npm.taobao.org/cliui/download/cliui-4.1.0.tgz",
+          "resolved": "https://registry.npmjs.org/cliui/-/cliui-4.1.0.tgz",
           "integrity": "sha1-NIQi2+gtgAswIu709qwQvy5NG0k=",
           "dev": true,
           "requires": {
@@ -11222,13 +11222,13 @@
           "dependencies": {
             "ansi-regex": {
               "version": "3.0.0",
-              "resolved": "https://registry.npm.taobao.org/ansi-regex/download/ansi-regex-3.0.0.tgz",
+              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
               "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
               "dev": true
             },
             "strip-ansi": {
               "version": "4.0.0",
-              "resolved": "https://registry.npm.taobao.org/strip-ansi/download/strip-ansi-4.0.0.tgz",
+              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
               "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
               "dev": true,
               "requires": {
@@ -11239,7 +11239,7 @@
         },
         "find-up": {
           "version": "3.0.0",
-          "resolved": "https://registry.npm.taobao.org/find-up/download/find-up-3.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
           "integrity": "sha1-SRafHXmTQwZG2mHsxa41XCHJe3M=",
           "dev": true,
           "requires": {
@@ -11248,19 +11248,19 @@
         },
         "get-caller-file": {
           "version": "1.0.3",
-          "resolved": "https://registry.npm.taobao.org/get-caller-file/download/get-caller-file-1.0.3.tgz",
+          "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.3.tgz",
           "integrity": "sha1-+Xj6TJDR3+f/LWvtoqUV5xO9z0o=",
           "dev": true
         },
         "is-absolute-url": {
           "version": "3.0.0",
-          "resolved": "https://registry.npm.taobao.org/is-absolute-url/download/is-absolute-url-3.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/is-absolute-url/-/is-absolute-url-3.0.0.tgz",
           "integrity": "sha1-6yHWnfLtjvcqPm8kPiFlYwNqCRM=",
           "dev": true
         },
         "is-fullwidth-code-point": {
           "version": "1.0.0",
-          "resolved": "https://registry.npm.taobao.org/is-fullwidth-code-point/download/is-fullwidth-code-point-1.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
           "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
           "dev": true,
           "requires": {
@@ -11269,7 +11269,7 @@
         },
         "locate-path": {
           "version": "3.0.0",
-          "resolved": "https://registry.npm.taobao.org/locate-path/download/locate-path-3.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
           "integrity": "sha1-2+w7OrdZdYBxtY/ln8QYca8hQA4=",
           "dev": true,
           "requires": {
@@ -11279,7 +11279,7 @@
         },
         "p-limit": {
           "version": "2.2.0",
-          "resolved": "https://registry.npm.taobao.org/p-limit/download/p-limit-2.2.0.tgz",
+          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.2.0.tgz",
           "integrity": "sha1-QXyZQeYCepq8ulCS3SkE4lW1+8I=",
           "dev": true,
           "requires": {
@@ -11288,7 +11288,7 @@
         },
         "p-locate": {
           "version": "3.0.0",
-          "resolved": "https://registry.npm.taobao.org/p-locate/download/p-locate-3.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
           "integrity": "sha1-Mi1poFwCZLJZl9n0DNiokasAZKQ=",
           "dev": true,
           "requires": {
@@ -11297,19 +11297,19 @@
         },
         "p-try": {
           "version": "2.2.0",
-          "resolved": "https://registry.npm.taobao.org/p-try/download/p-try-2.2.0.tgz",
+          "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
           "integrity": "sha1-yyhoVA4xPWHeWPr741zpAE1VQOY=",
           "dev": true
         },
         "require-main-filename": {
           "version": "1.0.1",
-          "resolved": "https://registry.npm.taobao.org/require-main-filename/download/require-main-filename-1.0.1.tgz",
+          "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-1.0.1.tgz",
           "integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE=",
           "dev": true
         },
         "schema-utils": {
           "version": "1.0.0",
-          "resolved": "https://registry.npm.taobao.org/schema-utils/download/schema-utils-1.0.0.tgz?cache=0&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fschema-utils%2Fdownload%2Fschema-utils-1.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-1.0.0.tgz",
           "integrity": "sha1-C3mpMgTXtgDUsoUNH2bCo0lRx3A=",
           "dev": true,
           "requires": {
@@ -11320,13 +11320,13 @@
         },
         "semver": {
           "version": "6.3.0",
-          "resolved": "https://registry.npm.taobao.org/semver/download/semver-6.3.0.tgz",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
           "integrity": "sha1-7gpkyK9ejO6mdoexM3YeG+y9HT0=",
           "dev": true
         },
         "strip-ansi": {
           "version": "3.0.1",
-          "resolved": "https://registry.npm.taobao.org/strip-ansi/download/strip-ansi-3.0.1.tgz",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "dev": true,
           "requires": {
@@ -11335,7 +11335,7 @@
         },
         "supports-color": {
           "version": "6.1.0",
-          "resolved": "https://registry.npm.taobao.org/supports-color/download/supports-color-6.1.0.tgz",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
           "integrity": "sha1-B2Srxpxj1ayELdSGfo0CXogN+PM=",
           "dev": true,
           "requires": {
@@ -11344,7 +11344,7 @@
         },
         "wrap-ansi": {
           "version": "2.1.0",
-          "resolved": "https://registry.npm.taobao.org/wrap-ansi/download/wrap-ansi-2.1.0.tgz?cache=0&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fwrap-ansi%2Fdownload%2Fwrap-ansi-2.1.0.tgz",
+          "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
           "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
           "dev": true,
           "requires": {
@@ -11354,7 +11354,7 @@
           "dependencies": {
             "string-width": {
               "version": "1.0.2",
-              "resolved": "https://registry.npm.taobao.org/string-width/download/string-width-1.0.2.tgz",
+              "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
               "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
               "dev": true,
               "requires": {
@@ -11367,7 +11367,7 @@
         },
         "yargs": {
           "version": "12.0.5",
-          "resolved": "https://registry.npm.taobao.org/yargs/download/yargs-12.0.5.tgz",
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-12.0.5.tgz",
           "integrity": "sha1-BfWZe2CWR7ZPZrgeO0sQo2jnrRM=",
           "dev": true,
           "requires": {
@@ -11387,7 +11387,7 @@
         },
         "yargs-parser": {
           "version": "11.1.1",
-          "resolved": "https://registry.npm.taobao.org/yargs-parser/download/yargs-parser-11.1.1.tgz?cache=0&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fyargs-parser%2Fdownload%2Fyargs-parser-11.1.1.tgz",
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-11.1.1.tgz",
           "integrity": "sha1-h5oIZZc7yp9rq1y987HGfsfTvPQ=",
           "dev": true,
           "requires": {
@@ -11399,7 +11399,7 @@
     },
     "webpack-log": {
       "version": "2.0.0",
-      "resolved": "https://registry.npm.taobao.org/webpack-log/download/webpack-log-2.0.0.tgz?cache=0&sync_timestamp=1564684667159&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fwebpack-log%2Fdownload%2Fwebpack-log-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/webpack-log/-/webpack-log-2.0.0.tgz",
       "integrity": "sha1-W3ko4GN1k/EZ0y9iJ8HgrDHhtH8=",
       "dev": true,
       "requires": {
@@ -11409,7 +11409,7 @@
     },
     "webpack-merge": {
       "version": "4.2.1",
-      "resolved": "https://registry.npm.taobao.org/webpack-merge/download/webpack-merge-4.2.1.tgz",
+      "resolved": "https://registry.npmjs.org/webpack-merge/-/webpack-merge-4.2.1.tgz",
       "integrity": "sha1-XpI8+ALqKs5P1a8dMkc2imM0ibQ=",
       "dev": true,
       "requires": {
@@ -11418,7 +11418,7 @@
     },
     "webpack-sources": {
       "version": "1.4.3",
-      "resolved": "https://registry.npm.taobao.org/webpack-sources/download/webpack-sources-1.4.3.tgz?cache=0&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fwebpack-sources%2Fdownload%2Fwebpack-sources-1.4.3.tgz",
+      "resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-1.4.3.tgz",
       "integrity": "sha1-7t2OwLko+/HL/plOItLYkPMwqTM=",
       "dev": true,
       "requires": {
@@ -11428,7 +11428,7 @@
       "dependencies": {
         "source-map": {
           "version": "0.6.1",
-          "resolved": "https://registry.npm.taobao.org/source-map/download/source-map-0.6.1.tgz",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
           "integrity": "sha1-dHIq8y6WFOnCh6jQu95IteLxomM=",
           "dev": true
         }
@@ -11436,7 +11436,7 @@
     },
     "websocket-driver": {
       "version": "0.7.3",
-      "resolved": "https://registry.npm.taobao.org/websocket-driver/download/websocket-driver-0.7.3.tgz?cache=0&sync_timestamp=1560468440028&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fwebsocket-driver%2Fdownload%2Fwebsocket-driver-0.7.3.tgz",
+      "resolved": "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.7.3.tgz",
       "integrity": "sha1-otTg1PTxFvHmKX66WLBdQwEA6fk=",
       "dev": true,
       "requires": {
@@ -11447,13 +11447,13 @@
     },
     "websocket-extensions": {
       "version": "0.1.3",
-      "resolved": "https://registry.npm.taobao.org/websocket-extensions/download/websocket-extensions-0.1.3.tgz",
+      "resolved": "https://registry.npmjs.org/websocket-extensions/-/websocket-extensions-0.1.3.tgz",
       "integrity": "sha1-XS/yKXcAPsaHpLhwc9+7rBRszyk=",
       "dev": true
     },
     "which": {
       "version": "1.3.1",
-      "resolved": "https://registry.npm.taobao.org/which/download/which-1.3.1.tgz",
+      "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
       "integrity": "sha1-pFBD1U9YBTFtqNYvn1CRjT2nCwo=",
       "dev": true,
       "requires": {
@@ -11462,19 +11462,19 @@
     },
     "which-module": {
       "version": "2.0.0",
-      "resolved": "https://registry.npm.taobao.org/which-module/download/which-module-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
       "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=",
       "dev": true
     },
     "wordwrap": {
       "version": "1.0.0",
-      "resolved": "https://registry.npm.taobao.org/wordwrap/download/wordwrap-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
       "integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus=",
       "dev": true
     },
     "worker-farm": {
       "version": "1.7.0",
-      "resolved": "https://registry.npm.taobao.org/worker-farm/download/worker-farm-1.7.0.tgz",
+      "resolved": "https://registry.npmjs.org/worker-farm/-/worker-farm-1.7.0.tgz",
       "integrity": "sha1-JqlMU5G7ypJhUgAvabhKS/dy5ag=",
       "dev": true,
       "requires": {
@@ -11483,7 +11483,7 @@
     },
     "wrap-ansi": {
       "version": "5.1.0",
-      "resolved": "https://registry.npm.taobao.org/wrap-ansi/download/wrap-ansi-5.1.0.tgz?cache=0&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fwrap-ansi%2Fdownload%2Fwrap-ansi-5.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-5.1.0.tgz",
       "integrity": "sha1-H9H2cjXVttD+54EFYAG/tpTAOwk=",
       "dev": true,
       "requires": {
@@ -11494,7 +11494,7 @@
       "dependencies": {
         "string-width": {
           "version": "3.1.0",
-          "resolved": "https://registry.npm.taobao.org/string-width/download/string-width-3.1.0.tgz",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
           "integrity": "sha1-InZ74htirxCBV0MG9prFG2IgOWE=",
           "dev": true,
           "requires": {
@@ -11507,13 +11507,13 @@
     },
     "wrappy": {
       "version": "1.0.2",
-      "resolved": "https://registry.npm.taobao.org/wrappy/download/wrappy-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
       "dev": true
     },
     "write": {
       "version": "0.2.1",
-      "resolved": "https://registry.npm.taobao.org/write/download/write-0.2.1.tgz",
+      "resolved": "https://registry.npmjs.org/write/-/write-0.2.1.tgz",
       "integrity": "sha1-X8A4KOJkzqP+kUVUdvejxWbLB1c=",
       "dev": true,
       "optional": true,
@@ -11523,7 +11523,7 @@
     },
     "ws": {
       "version": "6.2.1",
-      "resolved": "https://registry.npm.taobao.org/ws/download/ws-6.2.1.tgz",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-6.2.1.tgz",
       "integrity": "sha1-RC/fCkftZPWbal2P8TD0dI7VJPs=",
       "dev": true,
       "requires": {
@@ -11532,25 +11532,25 @@
     },
     "xtend": {
       "version": "4.0.2",
-      "resolved": "https://registry.npm.taobao.org/xtend/download/xtend-4.0.2.tgz?cache=0&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fxtend%2Fdownload%2Fxtend-4.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
       "integrity": "sha1-u3J3n1+kZRhrH0OPZ0+jR/2121Q=",
       "dev": true
     },
     "y18n": {
       "version": "4.0.0",
-      "resolved": "https://registry.npm.taobao.org/y18n/download/y18n-4.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.0.tgz",
       "integrity": "sha1-le+U+F7MgdAHwmThkKEg8KPIVms=",
       "dev": true
     },
     "yallist": {
       "version": "3.0.3",
-      "resolved": "https://registry.npm.taobao.org/yallist/download/yallist-3.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.3.tgz",
       "integrity": "sha1-tLBJ4xS+VF486AIjbWzSLNkcPek=",
       "dev": true
     },
     "yargs": {
       "version": "13.3.0",
-      "resolved": "https://registry.npm.taobao.org/yargs/download/yargs-13.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-13.3.0.tgz",
       "integrity": "sha1-TGV6VeB+Xyz5R/ijZlZ8BKDe3IM=",
       "dev": true,
       "requires": {
@@ -11568,7 +11568,7 @@
       "dependencies": {
         "find-up": {
           "version": "3.0.0",
-          "resolved": "https://registry.npm.taobao.org/find-up/download/find-up-3.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
           "integrity": "sha1-SRafHXmTQwZG2mHsxa41XCHJe3M=",
           "dev": true,
           "requires": {
@@ -11577,7 +11577,7 @@
         },
         "locate-path": {
           "version": "3.0.0",
-          "resolved": "https://registry.npm.taobao.org/locate-path/download/locate-path-3.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
           "integrity": "sha1-2+w7OrdZdYBxtY/ln8QYca8hQA4=",
           "dev": true,
           "requires": {
@@ -11587,7 +11587,7 @@
         },
         "p-limit": {
           "version": "2.2.0",
-          "resolved": "https://registry.npm.taobao.org/p-limit/download/p-limit-2.2.0.tgz",
+          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.2.0.tgz",
           "integrity": "sha1-QXyZQeYCepq8ulCS3SkE4lW1+8I=",
           "dev": true,
           "requires": {
@@ -11596,7 +11596,7 @@
         },
         "p-locate": {
           "version": "3.0.0",
-          "resolved": "https://registry.npm.taobao.org/p-locate/download/p-locate-3.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
           "integrity": "sha1-Mi1poFwCZLJZl9n0DNiokasAZKQ=",
           "dev": true,
           "requires": {
@@ -11605,13 +11605,13 @@
         },
         "p-try": {
           "version": "2.2.0",
-          "resolved": "https://registry.npm.taobao.org/p-try/download/p-try-2.2.0.tgz",
+          "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
           "integrity": "sha1-yyhoVA4xPWHeWPr741zpAE1VQOY=",
           "dev": true
         },
         "string-width": {
           "version": "3.1.0",
-          "resolved": "https://registry.npm.taobao.org/string-width/download/string-width-3.1.0.tgz",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
           "integrity": "sha1-InZ74htirxCBV0MG9prFG2IgOWE=",
           "dev": true,
           "requires": {
@@ -11624,7 +11624,7 @@
     },
     "yargs-parser": {
       "version": "13.1.1",
-      "resolved": "https://registry.npm.taobao.org/yargs-parser/download/yargs-parser-13.1.1.tgz?cache=0&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fyargs-parser%2Fdownload%2Fyargs-parser-13.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-13.1.1.tgz",
       "integrity": "sha1-0mBYUyqgbTZf4JH2ofwGsvfl7KA=",
       "dev": true,
       "requires": {
@@ -11634,7 +11634,7 @@
     },
     "yorkie": {
       "version": "2.0.0",
-      "resolved": "https://registry.npm.taobao.org/yorkie/download/yorkie-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/yorkie/-/yorkie-2.0.0.tgz",
       "integrity": "sha1-kkEZEtQ1IU4SxRwq4Qk+VLa7g9k=",
       "dev": true,
       "requires": {
@@ -11646,7 +11646,7 @@
       "dependencies": {
         "cross-spawn": {
           "version": "5.1.0",
-          "resolved": "https://registry.npm.taobao.org/cross-spawn/download/cross-spawn-5.1.0.tgz",
+          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
           "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
           "dev": true,
           "requires": {
@@ -11657,7 +11657,7 @@
         },
         "execa": {
           "version": "0.8.0",
-          "resolved": "https://registry.npm.taobao.org/execa/download/execa-0.8.0.tgz?cache=0&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fexeca%2Fdownload%2Fexeca-0.8.0.tgz",
+          "resolved": "https://registry.npmjs.org/execa/-/execa-0.8.0.tgz",
           "integrity": "sha1-2NdrvBtVIX7RkP1t1J08d07PyNo=",
           "dev": true,
           "requires": {
@@ -11672,13 +11672,13 @@
         },
         "get-stream": {
           "version": "3.0.0",
-          "resolved": "https://registry.npm.taobao.org/get-stream/download/get-stream-3.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
           "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ=",
           "dev": true
         },
         "lru-cache": {
           "version": "4.1.5",
-          "resolved": "https://registry.npm.taobao.org/lru-cache/download/lru-cache-4.1.5.tgz",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.5.tgz",
           "integrity": "sha1-i75Q6oW+1ZvJ4z3KuCNe6bz0Q80=",
           "dev": true,
           "requires": {
@@ -11688,13 +11688,13 @@
         },
         "normalize-path": {
           "version": "1.0.0",
-          "resolved": "https://registry.npm.taobao.org/normalize-path/download/normalize-path-1.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-1.0.0.tgz",
           "integrity": "sha1-MtDkcvkf80VwHBWoMRAY07CpA3k=",
           "dev": true
         },
         "yallist": {
           "version": "2.1.2",
-          "resolved": "https://registry.npm.taobao.org/yallist/download/yallist-2.1.2.tgz",
+          "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
           "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=",
           "dev": true
         }


### PR DESCRIPTION
## Summary
`npm install` em `website/` falha com `CERT_HAS_EXPIRED` porque o `package-lock.json` aponta para `registry.npm.taobao.org`, um mirror descontinuado com certificado TLS expirado. Como o npm usa as URLs `resolved` do lockfile literalmente (ignorando o `registry` configurado globalmente), nao adianta apenas mudar a config local.

- Reescreve 1215 URLs `resolved` para `registry.npmjs.org` com o path correto (`/pkg/download/pkg-v.tgz` -> `/pkg/-/pkg-v.tgz`, com tratamento de scoped packages)
- Remove query strings stale (`?cache=`, `&other_urls=`, `&sync_timestamp=`) deixadas pelo mirror
- Hashes de `integrity` permanecem validos (taobao era espelho byte-a-byte do npmjs)

## Test plan
- [x] `npm install` em `website/` instala 1262 pacotes sem erro
- [ ] Validar que `npm run build` em `website/` gera `dist/` corretamente
- [ ] Validar que `npm run serve` em `website/` sobe o dev server